### PR TITLE
[#24] ✨ Add PDF viewer widget with zoom and search + example screen

### DIFF
--- a/codifyiq_core_components/CHANGELOG.md
+++ b/codifyiq_core_components/CHANGELOG.md
@@ -10,6 +10,18 @@
   * Optional `NotificationCenterScope` `InheritedNotifier` exposes the controller ambiently so any descendant widget can post updates without prop-drilling
   * UI-only: consumers wire the controller to their own task layer (HTTP, isolates, platform background workers, etc.)
 * `BrightnessButton` now renders its dropdown as a Material 3 surface (rounded corners, elevation, surface tint) and accepts `menuAlignmentOffset` / `menuScreenEdgeInset` to control drop distance and the gap from the trailing viewport edge — matching the new `NotificationBellButton` styling
+* New widget: `PdfViewerWidget` — a reusable PDF viewer backed by `pdfrx`
+  * Render a PDF from any `PdfSource`: network `Uri`, local file path, or in-memory `Uint8List`
+  * Pinch-to-zoom on mobile; Ctrl/Cmd + scroll-wheel and on-screen +/− buttons on web
+  * Configurable `minScale` / `maxScale` zoom bounds — the supplied `minScale` is now honored as a literal lower bound (previously could be overridden by an internal fit-page calculation, which also produced a transient assertion on wide viewports during the first frame)
+  * Optional in-document text search with debounced input, highlighted matches, next/previous navigation, and a match counter — toggling `enableSearch` off clears any active query and removes in-page match highlights
+  * `PdfSource.uri` now accepts optional HTTP `headers`, forwarded to the underlying request — load PDFs from endpoints that require authentication/authorization (e.g. a JWT bearer token)
+  * Swapping the `source` at runtime now resets viewer state (page indicator, search input, match highlights) and rebinds the text searcher to the new document instead of carrying the previous document's state forward
+  * `PdfSource` variants (`PdfUriSource`, `PdfFileSource`, `PdfBytesSource`) now implement value equality, so two sources describing the same document compare equal
+  * Optional page indicator overlay
+  * Page change and document-loaded callbacks, plus a customizable error builder
+* Added `pdfrx ^2.3.3` dependency — required to render PDF documents
+* **Breaking:** minimum SDK requirements raised to Dart `^3.10.0` and Flutter `>=3.41.0` to satisfy `pdfrx`
 * New widget: `SocialSignInScreen` — customizable sign-in screen with logo, tagline, social buttons, error display, and footer
   * Optional reviewer login easter egg for app store submissions — tap the logo to reveal an email/password form for reviewers
   * Built-in processing state replaces sign-in buttons with a progress indicator during authentication, preventing duplicate taps

--- a/codifyiq_core_components/README.md
+++ b/codifyiq_core_components/README.md
@@ -139,6 +139,56 @@ their own branding, buttons, and authentication callbacks. It features:
 > * **Google:** [Google Identity Branding Guidelines](https://developers.google.com/identity/branding-guidelines)
 > * **Apple:** [Apple Design Resources](https://developer.apple.com/design/human-interface-guidelines/sign-in-with-apple)
 
+### `PdfViewerWidget`
+
+A reusable PDF viewer backed by [`pdfrx`](https://pub.dev/packages/pdfrx).
+Renders a document from a network URI, a local file path, or in-memory bytes
+via a single `PdfSource` parameter.
+
+```dart
+PdfViewerWidget(
+  source: PdfSource.uri(Uri.parse('https://example.com/file.pdf')),
+  enableSearch: true,
+  onDocumentLoaded: (pageCount) => debugPrint('Loaded $pageCount pages'),
+)
+```
+
+**What this adds on top of `pdfrx`:**
+
+*   **Built-in search UI.** `pdfrx` exposes `PdfTextSearcher` (state, match data,
+    paint callback) but ships no widget. This widget supplies the Material
+    search bar, debounced input, a match counter, and next/previous controls
+    that wrap around at both ends of the document.
+*   **Consistent zoom bounds.** The literal `minScale` and `maxScale` you pass
+    are honored by every input method (pinch, +/− buttons, Ctrl/Cmd +
+    scroll-wheel) — `pdfrx`'s default sizing and zoom-stop behavior would
+    otherwise let the buttons drive zoom outside those bounds.
+*   **On-screen web zoom buttons** and a **page indicator overlay**, neither of
+    which `pdfrx` provides out of the box.
+*   **A unified `PdfSource` parameter** in place of `pdfrx`'s separate
+    `PdfViewer.uri` / `.file` / `.data` constructors. `PdfSource` variants are
+    value-equal, so swapping documents at runtime works cleanly with
+    state-management diffing.
+
+Pinch-to-zoom, keyboard navigation, and page tracking are `pdfrx` defaults and
+pass through unchanged.
+
+For PDFs behind an authenticated endpoint, pass HTTP headers via
+`PdfSource.uri`:
+
+```dart
+PdfViewerWidget(
+  source: PdfSource.uri(
+    Uri.parse('https://api.example.com/documents/42.pdf'),
+    headers: {'Authorization': 'Bearer $jwt'},
+  ),
+)
+```
+
+> **Web note:** PDFs loaded via `PdfSource.uri` require the target server to
+> send appropriate CORS headers. `PdfSource.file` is not supported on the web
+> platform.
+
 ### Examples
 You can find sample code in the `example` directory as well as more details in the
 [Examples README](./example/README.md) for details.

--- a/codifyiq_core_components/devtools_options.yaml
+++ b/codifyiq_core_components/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/codifyiq_core_components/example/lib/pdf_viewer_widget_example.dart
+++ b/codifyiq_core_components/example/lib/pdf_viewer_widget_example.dart
@@ -1,0 +1,63 @@
+import 'package:codifyiq_core_components/codifyiq_core_components.dart';
+import 'package:flutter/material.dart';
+
+/// An example page that demonstrates the [PdfViewerWidget].
+///
+/// Shows a single PDF loaded from a network URL with search enabled. The
+/// minimal snippet below illustrates the smallest possible usage; the full
+/// page wraps it with an [AppBar] for the demo catalog.
+///
+/// ```dart
+/// PdfViewerWidget(
+///   source: PdfSource.uri(Uri.parse('https://example.com/file.pdf')),
+///   enableSearch: true,
+/// )
+/// ```
+class PdfViewerWidgetExample extends StatefulWidget {
+  /// Creates an instance of [PdfViewerWidgetExample].
+  const PdfViewerWidgetExample({super.key});
+
+  @override
+  State<PdfViewerWidgetExample> createState() => _PdfViewerWidgetExampleState();
+}
+
+class _PdfViewerWidgetExampleState extends State<PdfViewerWidgetExample> {
+  bool _enableSearch = true;
+
+  static final Uri _sampleUri = Uri.parse(
+    'https://raw.githubusercontent.com/mozilla/pdf.js/master/test/pdfs/tracemonkey.pdf',
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('PDF Viewer Example'),
+        actions: [
+          const Text('Search'),
+          Switch(
+            value: _enableSearch,
+            onChanged: (value) => setState(() => _enableSearch = value),
+          ),
+          const SizedBox(width: 8),
+        ],
+      ),
+      body: PdfViewerWidget(
+        source: PdfSource.uri(_sampleUri),
+        enableSearch: _enableSearch,
+        onDocumentLoaded: (pageCount) => debugPrint('Loaded $pageCount pages'),
+        onPageChanged: (page) => debugPrint('On page $page'),
+        errorBuilder: (context, error) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              'Could not load PDF:\n$error',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/codifyiq_core_components/example/lib/router.dart
+++ b/codifyiq_core_components/example/lib/router.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'ai_progress_indicator_example.dart';
 import 'error_retry_widget_example.dart';
 import 'notification_center_example.dart';
+import 'pdf_viewer_widget_example.dart';
 import 'social_sign_in_screen_example.dart';
 import 'terms_and_conditions_widget_example.dart';
 import 'widget_catalog.dart';
@@ -67,6 +68,12 @@ ShellRoute _getMainApplicationShellRoute() {
         path: "/notification-center",
         builder: (BuildContext context, GoRouterState state) {
           return NotificationCenterExample();
+        },
+      ),
+      GoRoute(
+        path: "/pdf-viewer",
+        builder: (BuildContext context, GoRouterState state) {
+          return PdfViewerWidgetExample();
         },
       ),
     ],

--- a/codifyiq_core_components/example/lib/widget_catalog.dart
+++ b/codifyiq_core_components/example/lib/widget_catalog.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'ai_progress_indicator_example.dart';
 import 'error_retry_widget_example.dart';
 import 'notification_center_example.dart';
+import 'pdf_viewer_widget_example.dart';
 import 'social_sign_in_screen_example.dart';
 import 'terms_and_conditions_widget_example.dart';
 
@@ -37,6 +38,12 @@ class WidgetCatalog extends StatelessWidget {
       'description':
           'Play Store-style bell with progress tracking for long-running tasks',
       'route': NotificationCenterExample(),
+    },
+    {
+      'name': 'PDF Viewer',
+      'description':
+          'PDF viewer with zoom, page indicator, and optional text search',
+      'route': PdfViewerWidgetExample(),
     },
   ];
 

--- a/codifyiq_core_components/example/pubspec.yaml
+++ b/codifyiq_core_components/example/pubspec.yaml
@@ -4,7 +4,8 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.10.0
+  flutter: ">=3.41.0"
 
 dependencies:
   flutter:

--- a/codifyiq_core_components/lib/codifyiq_core_components.dart
+++ b/codifyiq_core_components/lib/codifyiq_core_components.dart
@@ -9,5 +9,7 @@ export 'widgets/notification_center/notification_center_controller.dart';
 export 'widgets/notification_center/notification_center_page.dart';
 export 'widgets/notification_center/notification_center_panel.dart';
 export 'widgets/notification_center/notification_item.dart';
+export 'widgets/pdf_source.dart';
+export 'widgets/pdf_viewer_widget.dart';
 export 'widgets/social_sign_in_screen.dart';
 export 'widgets/terms_and_conditions_widget.dart';

--- a/codifyiq_core_components/lib/widgets/pdf_source.dart
+++ b/codifyiq_core_components/lib/widgets/pdf_source.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/foundation.dart';
+
+/// The source from which a PDF document is loaded.
+///
+/// Construct one of the concrete variants and hand it to a `PdfViewerWidget`:
+///
+/// ```dart
+/// PdfViewerWidget(source: PdfSource.uri(Uri.parse('https://example.com/file.pdf')))
+/// PdfViewerWidget(source: PdfSource.file('/path/to/file.pdf'))
+/// PdfViewerWidget(source: PdfSource.bytes(myUint8List))
+/// ```
+sealed class PdfSource {
+  const PdfSource();
+
+  /// Loads a PDF from a network [Uri].
+  ///
+  /// [headers] are sent with the HTTP request — supply authentication or
+  /// authorization headers here (e.g. a JWT bearer token) for endpoints that
+  /// require them.
+  ///
+  /// On web, the target server must serve appropriate CORS headers.
+  const factory PdfSource.uri(Uri uri, {Map<String, String>? headers}) =
+      PdfUriSource;
+
+  /// Loads a PDF from a local file path. Not supported on web.
+  const factory PdfSource.file(String path) = PdfFileSource;
+
+  /// Loads a PDF from raw bytes already in memory.
+  ///
+  /// [sourceName] is an optional identifier used by the underlying renderer
+  /// for caching and error messages; defaults to `document.pdf`.
+  const factory PdfSource.bytes(Uint8List bytes, {String? sourceName}) =
+      PdfBytesSource;
+}
+
+/// A [PdfSource] backed by a network [Uri].
+final class PdfUriSource extends PdfSource {
+  /// Creates a [PdfUriSource] that loads from [uri].
+  ///
+  /// [headers] are sent with the HTTP request — use this to supply
+  /// authentication/authorization headers (e.g. a JWT bearer token).
+  const PdfUriSource(this.uri, {this.headers});
+
+  /// The URI to fetch the PDF from.
+  final Uri uri;
+
+  /// Optional HTTP headers sent with the request, e.g. for authentication.
+  final Map<String, String>? headers;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PdfUriSource &&
+          other.uri == uri &&
+          mapEquals(other.headers, headers));
+
+  @override
+  int get hashCode => Object.hash(
+    uri,
+    headers == null
+        ? null
+        : Object.hashAllUnordered(
+            headers!.entries.map((e) => Object.hash(e.key, e.value)),
+          ),
+  );
+}
+
+/// A [PdfSource] backed by a local file path.
+final class PdfFileSource extends PdfSource {
+  /// Creates a [PdfFileSource] that reads from [path].
+  const PdfFileSource(this.path);
+
+  /// The absolute or relative file path of the PDF.
+  final String path;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is PdfFileSource && other.path == path);
+
+  @override
+  int get hashCode => path.hashCode;
+}
+
+/// A [PdfSource] backed by in-memory bytes.
+final class PdfBytesSource extends PdfSource {
+  /// Creates a [PdfBytesSource] from [bytes].
+  const PdfBytesSource(this.bytes, {this.sourceName});
+
+  /// The raw PDF bytes.
+  final Uint8List bytes;
+
+  /// Optional identifier used for caching and diagnostics.
+  final String? sourceName;
+
+  // Bytes are compared by identity rather than content: equating two large
+  // buffers byte-for-byte would be O(n) and the common consumer pattern is
+  // to hold a stable Uint8List reference per document. Callers that want a
+  // reload should pass a new Uint8List.
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PdfBytesSource &&
+          identical(other.bytes, bytes) &&
+          other.sourceName == sourceName);
+
+  @override
+  int get hashCode => Object.hash(identityHashCode(bytes), sourceName);
+}

--- a/codifyiq_core_components/lib/widgets/pdf_viewer_widget.dart
+++ b/codifyiq_core_components/lib/widgets/pdf_viewer_widget.dart
@@ -1,0 +1,512 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:pdfrx/pdfrx.dart';
+
+import 'pdf_source.dart';
+
+/// A reusable PDF viewer with optional zoom controls, page indicator, and
+/// in-document text search.
+///
+/// Backed by the `pdfrx` rendering engine. Renders a PDF from any
+/// [PdfSource] — a network [Uri], local file path, or in-memory bytes.
+///
+/// ## Interactions
+///
+/// - **Mobile**: pinch-to-zoom and pan are enabled by default.
+/// - **Web**: Ctrl/Cmd + scroll-wheel zooms in and out; on-screen +/− buttons
+///   are also shown when [showZoomControlsOnWeb] is true.
+/// - **All platforms**: keyboard navigation (arrow keys, Page Up/Down) is
+///   enabled by default.
+///
+/// ## Search
+///
+/// When [enableSearch] is `true`, a search bar appears above the viewer.
+/// Typed queries are debounced by [searchDebounce] before being submitted to
+/// the underlying [PdfTextSearcher]. Matches are highlighted in-document via
+/// `pagePaintCallbacks` and the user can step between them with the next/
+/// previous controls. A status label indicates the current match position or
+/// "No matches" when the query has no hits.
+///
+/// ## Error handling
+///
+/// If [errorBuilder] is provided it replaces the default in-viewer error
+/// banner shown when the document fails to load (bad URL, malformed bytes,
+/// missing file, etc.).
+class PdfViewerWidget extends StatefulWidget {
+  /// Creates a [PdfViewerWidget].
+  const PdfViewerWidget({
+    super.key,
+    required this.source,
+    this.enableSearch = false,
+    this.showZoomControlsOnWeb = true,
+    this.showPageIndicator = true,
+    this.minScale = 0.5,
+    this.maxScale = 4.0,
+    this.onPageChanged,
+    this.onDocumentLoaded,
+    this.errorBuilder,
+    this.searchDebounce = const Duration(milliseconds: 300),
+  }) : assert(minScale > 0 && minScale <= maxScale);
+
+  /// The PDF document to render.
+  final PdfSource source;
+
+  /// Whether the in-document search bar is shown.
+  final bool enableSearch;
+
+  /// Whether +/− zoom buttons are shown on web. Has no effect on other
+  /// platforms, where pinch-to-zoom is the primary zoom interaction.
+  final bool showZoomControlsOnWeb;
+
+  /// Whether the "Page X / Y" overlay is shown in the bottom-right corner.
+  final bool showPageIndicator;
+
+  /// Lower bound for the zoom level passed to `pdfrx`.
+  final double minScale;
+
+  /// Upper bound for the zoom level passed to `pdfrx`.
+  final double maxScale;
+
+  /// Called whenever the visible page changes. Receives the 1-based page
+  /// number.
+  final ValueChanged<int>? onPageChanged;
+
+  /// Called once the document has loaded successfully. Receives the total
+  /// page count.
+  final void Function(int pageCount)? onDocumentLoaded;
+
+  /// Optional builder for an error UI shown in place of the document when
+  /// loading fails.
+  final Widget Function(BuildContext context, Object error)? errorBuilder;
+
+  /// Idle time before a typed search query is submitted to the searcher.
+  final Duration searchDebounce;
+
+  @override
+  State<PdfViewerWidget> createState() => _PdfViewerWidgetState();
+}
+
+class _PdfViewerWidgetState extends State<PdfViewerWidget> {
+  late final PdfViewerController _controller;
+  // Lazily created inside onViewerReady: pdfrx's PdfTextSearcher constructor
+  // immediately dereferences controller.document, which only exists after the
+  // viewer attaches and the document has loaded.
+  PdfTextSearcher? _searcher;
+  final TextEditingController _searchInput = TextEditingController();
+  Timer? _debounce;
+
+  bool _viewerReady = false;
+  int? _currentPage;
+  int _pageCount = 0;
+  bool _querySubmitted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = PdfViewerController();
+  }
+
+  @override
+  void didUpdateWidget(covariant PdfViewerWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    final sourceChanged = oldWidget.source != widget.source;
+    final searchDisabled = oldWidget.enableSearch && !widget.enableSearch;
+    if (!sourceChanged && !searchDisabled) {
+      return;
+    }
+    setState(() {
+      if (sourceChanged) {
+        _resetStateForNewSource();
+      } else if (searchDisabled) {
+        _clearSearchState(disposeSearcher: false);
+      }
+    });
+  }
+
+  void _clearSearchState({required bool disposeSearcher}) {
+    _debounce?.cancel();
+    _searchInput.clear();
+    _searcher?.resetTextSearch();
+    _querySubmitted = false;
+    if (disposeSearcher) {
+      _searcher
+        ?..removeListener(_onSearchUpdate)
+        ..dispose();
+      _searcher = null;
+    }
+  }
+
+  // Drops the searcher so onViewerReady recreates it bound to the freshly
+  // loaded document, and rolls viewer state back to "not ready yet" until the
+  // new document signals ready.
+  void _resetStateForNewSource() {
+    _clearSearchState(disposeSearcher: true);
+    _viewerReady = false;
+    _currentPage = null;
+    _pageCount = 0;
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchInput.dispose();
+    _searcher
+      ?..removeListener(_onSearchUpdate)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onSearchUpdate() {
+    if (mounted) setState(() {});
+  }
+
+  void _onSearchChanged(String query) {
+    _debounce?.cancel();
+    _debounce = Timer(widget.searchDebounce, () {
+      if (!mounted) return;
+      final searcher = _searcher;
+      if (searcher == null) return;
+      if (query.isEmpty) {
+        searcher.resetTextSearch();
+        setState(() => _querySubmitted = false);
+      } else {
+        searcher.startTextSearch(query);
+        setState(() => _querySubmitted = true);
+      }
+    });
+  }
+
+  void _paintMatches(Canvas canvas, Rect pageRect, PdfPage page) {
+    _searcher?.pageTextMatchPaintCallback(canvas, pageRect, page);
+  }
+
+  // pdfrx's PdfTextSearcher updates currentIndex in goToNext/PrevMatch but
+  // does not notify listeners, so the "X of Y" label only refreshes when
+  // navigation crosses a page boundary (which incidentally triggers a
+  // rebuild via onPageChanged). setState here keeps the label in sync for
+  // same-page navigation too. pdfrx also stops at the ends instead of
+  // wrapping, so detect the boundary and jump to the opposite end.
+  Future<void> _stepMatch({required bool forward}) async {
+    final searcher = _searcher;
+    if (searcher == null) return;
+    final total = searcher.matches.length;
+    if (total == 0) return;
+    final current = searcher.currentIndex;
+    if (forward) {
+      if (current != null && current >= total - 1) {
+        await searcher.goToMatchOfIndex(0);
+      } else {
+        await searcher.goToNextMatch();
+      }
+    } else {
+      if (current != null && current <= 0) {
+        await searcher.goToMatchOfIndex(total - 1);
+      } else {
+        await searcher.goToPrevMatch();
+      }
+    }
+    if (mounted) setState(() {});
+  }
+
+  Widget _buildViewer() {
+    final params = PdfViewerParams(
+      // pdfrx's default sizing delegate overrides minScale with an auto-
+      // computed "fit page" value. On the first frame the page number isn't
+      // set yet, so that value falls back to coverScale (viewport / document
+      // ratio), which can exceed maxScale on wide viewports and trip
+      // InteractiveViewer's `maxScale >= minScale` assertion. Configure the
+      // delegate explicitly with useAlternativeFitScaleAsMinScale: false so
+      // the literal minScale is honored and the assertion always holds.
+      sizeDelegateProvider: PdfViewerSizeDelegateProviderLegacy(
+        minScale: widget.minScale,
+        maxScale: widget.maxScale,
+        useAlternativeFitScaleAsMinScale: false,
+      ),
+      // pdfrx's default zoom-steps delegate can emit an unsorted list when
+      // minScale falls between two power-of-two halvings of the fit-page
+      // scale (it inserts minScale at index 0 even if a smaller value sits
+      // at index 1). That makes the +/- buttons oscillate near the zoom-out
+      // bound. Sort the stops to give the controller a monotonic list.
+      zoomStepsDelegateProvider: const _SortedZoomStepsDelegateProvider(),
+      pagePaintCallbacks: [_paintMatches],
+      onViewerReady: (document, controller) {
+        if (!mounted) return;
+        _searcher ??= PdfTextSearcher(controller)..addListener(_onSearchUpdate);
+        setState(() {
+          _viewerReady = true;
+          _pageCount = controller.pageCount;
+          _currentPage = controller.pageNumber ?? 1;
+        });
+        widget.onDocumentLoaded?.call(controller.pageCount);
+      },
+      onPageChanged: (pageNumber) {
+        if (!mounted || pageNumber == null) return;
+        setState(() => _currentPage = pageNumber);
+        widget.onPageChanged?.call(pageNumber);
+      },
+      errorBannerBuilder: widget.errorBuilder == null
+          ? null
+          : (context, error, stackTrace, documentRef) =>
+                widget.errorBuilder!(context, error),
+    );
+
+    return switch (widget.source) {
+      PdfUriSource(:final uri, :final headers) => PdfViewer.uri(
+        uri,
+        controller: _controller,
+        params: params,
+        headers: headers,
+      ),
+      PdfFileSource(:final path) => PdfViewer.file(
+        path,
+        controller: _controller,
+        params: params,
+      ),
+      PdfBytesSource(:final bytes, :final sourceName) => PdfViewer.data(
+        bytes,
+        sourceName: sourceName ?? 'document.pdf',
+        controller: _controller,
+        params: params,
+      ),
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showWebZoom = kIsWeb && widget.showZoomControlsOnWeb;
+    return Column(
+      children: [
+        if (widget.enableSearch)
+          _PdfSearchBar(
+            controller: _searchInput,
+            enabled: _viewerReady,
+            onChanged: _onSearchChanged,
+            onNext: (_searcher?.matches.isNotEmpty ?? false)
+                ? () => _stepMatch(forward: true)
+                : null,
+            onPrev: (_searcher?.matches.isNotEmpty ?? false)
+                ? () => _stepMatch(forward: false)
+                : null,
+            statusLabel: _searchStatusLabel(),
+          ),
+        Expanded(
+          child: Stack(
+            children: [
+              Positioned.fill(child: _buildViewer()),
+              if (showWebZoom)
+                Positioned(
+                  right: 16,
+                  bottom: 16,
+                  child: _PdfZoomControls(
+                    onZoomIn: _viewerReady ? _controller.zoomUp : null,
+                    onZoomOut: _viewerReady ? _controller.zoomDown : null,
+                  ),
+                ),
+              if (widget.showPageIndicator && _viewerReady && _pageCount > 0)
+                Positioned(
+                  left: 16,
+                  bottom: 16,
+                  child: _PdfPageIndicator(
+                    currentPage: _currentPage ?? 1,
+                    pageCount: _pageCount,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  String? _searchStatusLabel() {
+    if (!_querySubmitted) return null;
+    final searcher = _searcher;
+    if (searcher == null) return null;
+    final total = searcher.matches.length;
+    if (total == 0) return 'No matches';
+    final current = (searcher.currentIndex ?? 0) + 1;
+    return '$current of $total';
+  }
+}
+
+class _PdfSearchBar extends StatelessWidget {
+  const _PdfSearchBar({
+    required this.controller,
+    required this.enabled,
+    required this.onChanged,
+    required this.onNext,
+    required this.onPrev,
+    required this.statusLabel,
+  });
+
+  final TextEditingController controller;
+  final bool enabled;
+  final ValueChanged<String> onChanged;
+  final VoidCallback? onNext;
+  final VoidCallback? onPrev;
+  final String? statusLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        child: Row(
+          children: [
+            Expanded(
+              // Rebuild on every keystroke so the Clear suffix appears/
+              // disappears synchronously with input. The parent state only
+              // rebuilds on debounce/search events, which would otherwise
+              // leave the suffix stale until the next setState upstream.
+              child: ValueListenableBuilder<TextEditingValue>(
+                valueListenable: controller,
+                builder: (context, value, _) {
+                  return TextField(
+                    controller: controller,
+                    enabled: enabled,
+                    onChanged: onChanged,
+                    textInputAction: TextInputAction.search,
+                    decoration: InputDecoration(
+                      isDense: true,
+                      hintText: 'Search in document',
+                      prefixIcon: const Icon(Icons.search, size: 20),
+                      suffixIcon: value.text.isEmpty
+                          ? null
+                          : IconButton(
+                              tooltip: 'Clear',
+                              icon: const Icon(Icons.close, size: 20),
+                              onPressed: () {
+                                controller.clear();
+                                onChanged('');
+                              },
+                            ),
+                      border: const OutlineInputBorder(),
+                    ),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(width: 8),
+            if (statusLabel != null)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                child: Text(statusLabel!, style: theme.textTheme.bodySmall),
+              ),
+            IconButton(
+              tooltip: 'Previous match',
+              icon: const Icon(Icons.keyboard_arrow_up),
+              onPressed: onPrev,
+            ),
+            IconButton(
+              tooltip: 'Next match',
+              icon: const Icon(Icons.keyboard_arrow_down),
+              onPressed: onNext,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PdfZoomControls extends StatelessWidget {
+  const _PdfZoomControls({required this.onZoomIn, required this.onZoomOut});
+
+  final VoidCallback? onZoomIn;
+  final VoidCallback? onZoomOut;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            tooltip: 'Zoom in',
+            icon: const Icon(Icons.add),
+            onPressed: onZoomIn,
+          ),
+          IconButton(
+            tooltip: 'Zoom out',
+            icon: const Icon(Icons.remove),
+            onPressed: onZoomOut,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PdfPageIndicator extends StatelessWidget {
+  const _PdfPageIndicator({required this.currentPage, required this.pageCount});
+
+  final int currentPage;
+  final int pageCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.inverseSurface.withValues(alpha: 0.85),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        'Page $currentPage / $pageCount',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onInverseSurface,
+        ),
+      ),
+    );
+  }
+}
+
+class _SortedZoomStepsDelegateProvider extends PdfViewerZoomStepsDelegateProvider {
+  const _SortedZoomStepsDelegateProvider();
+
+  @override
+  PdfViewerZoomStepsDelegate create() => _SortedZoomStepsDelegate();
+
+  @override
+  bool operator ==(Object other) => other is _SortedZoomStepsDelegateProvider;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+class _SortedZoomStepsDelegate implements PdfViewerZoomStepsDelegate {
+  final PdfViewerZoomStepsDelegateDefault _inner =
+      PdfViewerZoomStepsDelegateDefault();
+
+  @override
+  void dispose() => _inner.dispose();
+
+  // pdfrx's default delegate halves the fit-page scale until z > minScale is
+  // false, but it inserts each halved value before re-checking, so the final
+  // list contains a stop below minScale. The +/- buttons can then drive the
+  // zoom below the gesture/InteractiveViewer minimum, leaving the button and
+  // ctrl+scroll bounds inconsistent. Sort the stops and clip anything below
+  // minScale (with a small tolerance) so all input methods bottom out at the
+  // same value.
+  @override
+  List<double> generateZoomStops(PdfViewerLayoutMetrics metrics) {
+    final raw = _inner.generateZoomStops(metrics);
+    const epsilon = 0.001;
+    final filtered = raw.where((z) => z >= metrics.minScale - epsilon).toList()
+      ..sort();
+    if (filtered.isEmpty) {
+      return [metrics.minScale, metrics.maxScale];
+    }
+    if ((filtered.first - metrics.minScale).abs() > epsilon) {
+      filtered.insert(0, metrics.minScale);
+    }
+    return filtered;
+  }
+}

--- a/codifyiq_core_components/pubspec.yaml
+++ b/codifyiq_core_components/pubspec.yaml
@@ -15,8 +15,8 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ^3.9.2
-  flutter: ">=3.27.0"
+  sdk: ^3.10.0
+  flutter: ">=3.41.0"
 
 dependencies:
   flutter:
@@ -24,6 +24,7 @@ dependencies:
   gpt_markdown: ^1.1.5
   adaptive_theme: ^3.7.0
   shimmer: ^3.0.0
+  pdfrx: ^2.3.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Adds new PDF viewer widget
- Implements pinch‑to‑zoom and search functionality
- Adds example screen in the example app
- Updates tests to match new example app structure
- Rebases cleanly on latest dev

Closes #24 