### PR TITLE
[#32] ✨ Add AI chat widget + example screen

### DIFF
--- a/codifyiq_core_components/CHANGELOG.md
+++ b/codifyiq_core_components/CHANGELOG.md
@@ -1,17 +1,17 @@
 # Changelog
 
 ## 0.7.0
-* New widget: `AiChatScreen` — an embeddable AI chat experience built on top of the Flyer Chat packages (`flutter_chat_ui` + `flutter_chat_types`) and re-skinned to the Material 3 theme
+* New widget: `AiChatScreen` — an embeddable AI chat experience built on the Flyer Chat v2 packages (`flutter_chat_ui` + `flutter_chat_core`) and re-skinned to the Material 3 theme
   * Scrollable chat timeline with text messaging, multiline input, auto-scroll to the latest message, and a send button that stays visible but grayed out while the input is empty or a reply is in flight
   * Sending is blocked while the assistant is responding — the in-flight request is left to finish and the user's draft text is kept rather than cleared
-  * AI replies render as Markdown (headings, bold, lists, code blocks, links) via `gpt_markdown`; user messages render as plain text
+  * Messages render as Markdown (headings, bold, lists, code blocks, links) via `gpt_markdown`
   * On wide (desktop) viewports the conversation is centered in a max-width column with dimmed side gutters — tune or disable it with the `maxContentWidth` parameter
   * `AiChatController` manages the message timeline and the backend round-trip — supply your own request logic through its `responder` callback (the package ships no networking layer)
   * Shows an `AiProgressIndicator` while awaiting a reply and an error bubble when a request fails
   * Automatically stamps each message's `seenAt` timestamp the first time it scrolls into view
   * `onSendMessage` and `onMessageTap` callbacks — `onMessageTap` is the integration point for future PDF/image viewers
   * `CodifyChatMessage` model supports text, image, and pdf content plus sender and `seenAt`
-  * Image messages render inline through Flyer Chat — set `CodifyChatMessage.sourceUri` to a network or local image and it appears in the timeline with tap-to-zoom; set `enableImageGallery` to `false` to route image taps to `onMessageTap` for a custom viewer instead
+  * Image messages render inline through Flyer Chat — set `CodifyChatMessage.sourceUri` to a network or local image and it appears in the timeline; tapping it is delivered through `onMessageTap` so the host can open its own viewer
   * PDF messages render as tappable Flyer Chat file rows (document icon, name, and `fileSizeBytes` as the subtitle) — handle `onMessageTap` to open your own PDF viewer; the chat widget itself pulls in no PDF rendering library
   * A `+` attachment button opens an "Add image / Add PDF" menu — wire `onAttachImage` / `onAttachPdf` to your own file picker; the button is hidden when neither is provided
 * New widget set: `NotificationBellButton`, `NotificationCenterPanel`, `NotificationCenterPage`, and `NotificationCenterController` — a Play Store-style notification center for tracking long-running, user-initiated tasks

--- a/codifyiq_core_components/CHANGELOG.md
+++ b/codifyiq_core_components/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 ## 0.7.0
+* New widget: `AiChatScreen` — an embeddable AI chat experience built on top of the Flyer Chat packages (`flutter_chat_ui` + `flutter_chat_types`) and re-skinned to the Material 3 theme
+  * Scrollable chat timeline with text messaging, multiline input, auto-scroll to the latest message, and a send button that stays visible but grayed out while the input is empty or a reply is in flight
+  * Sending is blocked while the assistant is responding — the in-flight request is left to finish and the user's draft text is kept rather than cleared
+  * AI replies render as Markdown (headings, bold, lists, code blocks, links) via `gpt_markdown`; user messages render as plain text
+  * On wide (desktop) viewports the conversation is centered in a max-width column with dimmed side gutters — tune or disable it with the `maxContentWidth` parameter
+  * `AiChatController` manages the message timeline and the backend round-trip — supply your own request logic through its `responder` callback (the package ships no networking layer)
+  * Shows an `AiProgressIndicator` while awaiting a reply and an error bubble when a request fails
+  * Automatically stamps each message's `seenAt` timestamp the first time it scrolls into view
+  * `onSendMessage` and `onMessageTap` callbacks — `onMessageTap` is the integration point for future PDF/image viewers
+  * `CodifyChatMessage` model supports text, image, and pdf content plus sender and `seenAt`
+  * Image messages render inline through Flyer Chat — set `CodifyChatMessage.sourceUri` to a network or local image and it appears in the timeline with tap-to-zoom; set `enableImageGallery` to `false` to route image taps to `onMessageTap` for a custom viewer instead
+  * PDF messages render as tappable Flyer Chat file rows (document icon, name, and `fileSizeBytes` as the subtitle) — handle `onMessageTap` to open your own PDF viewer; the chat widget itself pulls in no PDF rendering library
+  * A `+` attachment button opens an "Add image / Add PDF" menu — wire `onAttachImage` / `onAttachPdf` to your own file picker; the button is hidden when neither is provided
 * New widget set: `NotificationBellButton`, `NotificationCenterPanel`, `NotificationCenterPage`, and `NotificationCenterController` — a Play Store-style notification center for tracking long-running, user-initiated tasks
   * App-bar bell with a stoplight-coded Material 3 badge — amber while work is in flight, green when every tracked item completed, and red when at least one item failed (failure always wins so a regression is never hidden behind an in-progress indicator)
   * Bell icon swaps to a filled variant whenever items are tracked, so state is conveyed by shape as well as color (WCAG 1.4.1)

--- a/codifyiq_core_components/example/lib/ai_chat_screen_example.dart
+++ b/codifyiq_core_components/example/lib/ai_chat_screen_example.dart
@@ -1,0 +1,138 @@
+import 'package:codifyiq_core_components/codifyiq_core_components.dart';
+import 'package:flutter/material.dart';
+
+/// Demo for [AiChatScreen] and [AiChatController].
+///
+/// A simulated backend echoes text replies after a short delay. Type a prompt
+/// containing certain keywords to exercise the other code paths:
+///
+/// - `pdf`   → a placeholder PDF response bubble
+/// - `image` → a placeholder image response bubble
+/// - `fail`  → a thrown error, surfaced as an error bubble
+class AiChatScreenExample extends StatefulWidget {
+  /// Creates an [AiChatScreenExample].
+  const AiChatScreenExample({super.key});
+
+  @override
+  State<AiChatScreenExample> createState() => _AiChatScreenExampleState();
+}
+
+class _AiChatScreenExampleState extends State<AiChatScreenExample> {
+  late final AiChatController _controller = AiChatController(
+    responder: _demoResponder,
+    initialMessages: [
+      CodifyChatMessage.ai(
+        text:
+            "Hi! I'm a demo assistant. Send me a message — or include the "
+            "words \"pdf\", \"image\", or \"fail\" to try those response "
+            "types.",
+      ),
+    ],
+  );
+
+  /// Stands in for a real backend call.
+  // A reliable public PDF used to demonstrate file messages end to end.
+  static final Uri _samplePdfUri = Uri.parse(
+    'https://raw.githubusercontent.com/mozilla/pdf.js/master/test/pdfs/tracemonkey.pdf',
+  );
+
+  Future<CodifyChatMessage> _demoResponder(String prompt) async {
+    await Future<void>.delayed(const Duration(milliseconds: 900));
+    final lower = prompt.toLowerCase();
+
+    if (lower.contains('fail')) {
+      throw Exception('Simulated backend failure');
+    }
+    if (lower.contains('pdf')) {
+      return CodifyChatMessage.pdf(
+        text: 'quarterly-report.pdf',
+        sourceUri: _samplePdfUri,
+        fileSizeBytes: 1055688,
+      );
+    }
+    if (lower.contains('image')) {
+      return CodifyChatMessage.image(
+        text: 'architecture-diagram.png',
+        sourceUri: Uri.parse('https://picsum.photos/seed/codifyiq-ai/600/400'),
+      );
+    }
+    return CodifyChatMessage.ai(
+      text:
+          'You said: **"$prompt"**.\n\n'
+          'This is a simulated reply, rendered as **Markdown**. A real app '
+          'would wire `AiChatController` to its backend via the responder '
+          'callback. Markdown supports:\n\n'
+          '- **bold** and *italic* text\n'
+          '- inline `code` and code blocks\n'
+          '- lists, headings, and links\n',
+    );
+  }
+
+  // A real app would open an image picker here; this demo simulates a picked
+  // file by appending a message that points at a sample network image.
+  void _handleAttachImage() {
+    _controller.addMessage(
+      CodifyChatMessage.image(
+        text: 'photo.png',
+        sender: CodifyChatSender.user,
+        sourceUri: Uri.parse(
+          'https://picsum.photos/seed/codifyiq-photo/600/400',
+        ),
+      ),
+    );
+  }
+
+  // Likewise for PDFs — the host app owns the document picker.
+  void _handleAttachPdf() {
+    _controller.addMessage(
+      CodifyChatMessage.pdf(
+        text: 'contract.pdf',
+        sender: CodifyChatSender.user,
+        sourceUri: _samplePdfUri,
+        fileSizeBytes: 1055688,
+      ),
+    );
+  }
+
+  void _handleMessageTap(CodifyChatMessage message) {
+    // Only PDF taps have a host action here: the chat widget never imports a
+    // PDF renderer, so the host wires onMessageTap to its own viewer — the
+    // package's PdfViewerWidget. Image taps are handled by Flyer's built-in
+    // gallery, and text/error taps have no natural action, so they are
+    // intentionally ignored.
+    if (message.kind == CodifyChatMessageKind.pdf &&
+        message.sourceUri != null) {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => Scaffold(
+            appBar: AppBar(
+              title: Text(message.text.isEmpty ? 'PDF' : message.text),
+            ),
+            body: PdfViewerWidget(source: PdfSource.uri(message.sourceUri!)),
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('AI Chat Example')),
+      body: AiChatScreen(
+        controller: _controller,
+        inputHint: 'Ask the assistant…',
+        onSendMessage: (text) => debugPrint('Sending: $text'),
+        onMessageTap: _handleMessageTap,
+        onAttachImage: _handleAttachImage,
+        onAttachPdf: _handleAttachPdf,
+      ),
+    );
+  }
+}

--- a/codifyiq_core_components/example/lib/ai_chat_screen_example.dart
+++ b/codifyiq_core_components/example/lib/ai_chat_screen_example.dart
@@ -95,24 +95,84 @@ class _AiChatScreenExampleState extends State<AiChatScreenExample> {
   }
 
   void _handleMessageTap(CodifyChatMessage message) {
-    // Only PDF taps have a host action here: the chat widget never imports a
-    // PDF renderer, so the host wires onMessageTap to its own viewer — the
-    // package's PdfViewerWidget. Image taps are handled by Flyer's built-in
-    // gallery, and text/error taps have no natural action, so they are
-    // intentionally ignored.
-    if (message.kind == CodifyChatMessageKind.pdf &&
-        message.sourceUri != null) {
-      Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (_) => Scaffold(
-            appBar: AppBar(
-              title: Text(message.text.isEmpty ? 'PDF' : message.text),
+    // The chat widget bundles no PDF or image renderer; the host wires
+    // onMessageTap to its own viewers. PDFs open the package's
+    // PdfViewerWidget; images open the package's ImageViewerWidget with every
+    // image in the conversation loaded so the user can swipe between them.
+    // Text and error taps have no natural action and are ignored.
+    final source = message.sourceUri;
+    if (source == null) return;
+
+    switch (message.kind) {
+      case CodifyChatMessageKind.pdf:
+        Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => Scaffold(
+              appBar: AppBar(
+                title: Text(message.text.isEmpty ? 'PDF' : message.text),
+              ),
+              body: PdfViewerWidget(source: PdfSource.uri(source)),
             ),
-            body: PdfViewerWidget(source: PdfSource.uri(message.sourceUri!)),
           ),
-        ),
-      );
+        );
+      case CodifyChatMessageKind.image:
+        _openImageViewer(message.id);
+      case CodifyChatMessageKind.text:
+      case CodifyChatMessageKind.error:
+        break;
     }
+  }
+
+  void _openImageViewer(String tappedId) {
+    // Build the items from every image message in the conversation so the
+    // viewer can swipe between them.
+    final images = _controller.messages
+        .where(
+          (m) => m.kind == CodifyChatMessageKind.image && m.sourceUri != null,
+        )
+        .toList(growable: false);
+    final initialIndex = images.indexWhere((m) => m.id == tappedId);
+    if (initialIndex == -1) return;
+
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        fullscreenDialog: true,
+        builder: (dialogContext) => ImageViewerWidget(
+          items: [
+            for (final m in images)
+              ImageViewerItem.network(
+                m.sourceUri!.toString(),
+                title: m.text.isEmpty ? null : m.text,
+              ),
+          ],
+          initialIndex: initialIndex,
+          // Wiring these callbacks is what makes the viewer's download icon
+          // and overflow (share / delete) menu appear — they hide individually
+          // when their callback is null. Real apps plug in their own logic;
+          // the demo just surfaces SnackBar feedback.
+          onDownload: (item, _) =>
+              _showViewerSnack(dialogContext, 'Download', item),
+          // onShare takes an extra Rect? for anchoring iPad share-sheets.
+          onShare: (item, _, _) =>
+              _showViewerSnack(dialogContext, 'Share', item),
+          onDelete: (item, _) =>
+              _showViewerSnack(dialogContext, 'Delete', item),
+        ),
+      ),
+    );
+  }
+
+  void _showViewerSnack(
+    BuildContext context,
+    String action,
+    ImageViewerItem item,
+  ) {
+    final title = item.title;
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(content: Text('$action${title == null ? '' : ': $title'}')),
+      );
   }
 
   @override

--- a/codifyiq_core_components/example/lib/router.dart
+++ b/codifyiq_core_components/example/lib/router.dart
@@ -3,6 +3,7 @@ import 'package:codifyiq_core_components/widgets/brightness_button.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import 'ai_chat_screen_example.dart';
 import 'ai_progress_indicator_example.dart';
 import 'error_retry_widget_example.dart';
 import 'notification_center_example.dart';
@@ -74,6 +75,12 @@ ShellRoute _getMainApplicationShellRoute() {
         path: "/pdf-viewer",
         builder: (BuildContext context, GoRouterState state) {
           return PdfViewerWidgetExample();
+        },
+      ),
+      GoRoute(
+        path: "/ai-chat",
+        builder: (BuildContext context, GoRouterState state) {
+          return AiChatScreenExample();
         },
       ),
     ],

--- a/codifyiq_core_components/example/lib/widget_catalog.dart
+++ b/codifyiq_core_components/example/lib/widget_catalog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'ai_chat_screen_example.dart';
 import 'ai_progress_indicator_example.dart';
 import 'error_retry_widget_example.dart';
 import 'notification_center_example.dart';
@@ -44,6 +45,12 @@ class WidgetCatalog extends StatelessWidget {
       'description':
           'PDF viewer with zoom, page indicator, and optional text search',
       'route': PdfViewerWidgetExample(),
+    },
+    {
+      'name': 'AI Chat',
+      'description':
+          'Wraps Flyer Chat with CodifyIQ styling for AI conversations',
+      'route': AiChatScreenExample(),
     },
   ];
 

--- a/codifyiq_core_components/lib/codifyiq_core_components.dart
+++ b/codifyiq_core_components/lib/codifyiq_core_components.dart
@@ -1,6 +1,9 @@
 /// CodifyIQ Core Components — reusable UI widgets for Flutter applications.
 library;
 
+export 'widgets/ai_chat/ai_chat_controller.dart';
+export 'widgets/ai_chat/ai_chat_screen.dart';
+export 'widgets/ai_chat/codify_chat_message.dart';
 export 'widgets/ai_progress_indicator.dart';
 export 'widgets/brightness_button.dart';
 export 'widgets/error_retry_widget.dart';

--- a/codifyiq_core_components/lib/widgets/ai_chat/ai_chat_controller.dart
+++ b/codifyiq_core_components/lib/widgets/ai_chat/ai_chat_controller.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/foundation.dart';
+
+import 'codify_chat_message.dart';
+
+/// Performs the backend round-trip for a chat turn.
+///
+/// Given the user's [prompt], returns the AI's reply as a [CodifyChatMessage]
+/// — typically [CodifyChatMessage.ai] for text, but may also be a
+/// [CodifyChatMessage.pdf] or [CodifyChatMessage.image] placeholder. Throwing
+/// from the responder makes [AiChatController] append an error bubble.
+///
+/// The package ships no networking layer: consumers wire the responder to
+/// their own API client, SDK, or mock.
+typedef AiChatResponder = Future<CodifyChatMessage> Function(String prompt);
+
+/// State manager for an AI chat conversation.
+///
+/// Owns the ordered message timeline and the request lifecycle for a single
+/// chat. `AiChatScreen` listens to this controller and rebuilds when it
+/// changes; the controller is otherwise UI-agnostic.
+///
+/// Typical flow:
+///
+/// 1. [sendText] appends the user's message, flips [isResponding] on, and
+///    awaits the injected [AiChatResponder].
+/// 2. On success the responder's message is appended; on failure an error
+///    bubble is appended instead.
+/// 3. [markSeen] stamps a message's `seenAt` the first time it becomes
+///    visible — `AiChatScreen` calls this from Flyer Chat's visibility
+///    callback.
+///
+/// Pass a custom [clock] to override [DateTime.now] in tests.
+class AiChatController extends ChangeNotifier {
+  /// Creates a controller backed by [responder].
+  ///
+  /// [initialMessages] seeds the timeline (e.g. a greeting). [clock] overrides
+  /// the timestamp source for [sendText] and [markSeen].
+  AiChatController({
+    required AiChatResponder responder,
+    List<CodifyChatMessage>? initialMessages,
+    DateTime Function()? clock,
+  }) : _responder = responder,
+       _clock = clock ?? DateTime.now,
+       _messages = List<CodifyChatMessage>.of(
+         initialMessages ?? const <CodifyChatMessage>[],
+       ) {
+    for (final message in _messages) {
+      _messagesById[message.id] = message;
+    }
+  }
+
+  final AiChatResponder _responder;
+  final DateTime Function() _clock;
+  final List<CodifyChatMessage> _messages;
+  // Id index kept in sync with [_messages] so [messageById] is O(1); it is
+  // called once per custom-message bubble on every rebuild.
+  final Map<String, CodifyChatMessage> _messagesById =
+      <String, CodifyChatMessage>{};
+  bool _isResponding = false;
+  bool _isDisposed = false;
+
+  /// The conversation timeline, oldest first. Unmodifiable.
+  List<CodifyChatMessage> get messages => List.unmodifiable(_messages);
+
+  /// Whether a backend request is currently in flight. While `true`,
+  /// `AiChatScreen` shows the loading indicator and ignores further sends.
+  bool get isResponding => _isResponding;
+
+  /// Whether the timeline has no messages.
+  bool get isEmpty => _messages.isEmpty;
+
+  /// Looks up a message by [id], or returns `null` if absent.
+  CodifyChatMessage? messageById(String id) => _messagesById[id];
+
+  /// Sends [text] as a user message and requests an AI reply.
+  ///
+  /// Blank input is ignored, as are sends issued while a request is already
+  /// [isResponding]. Listeners are notified when the user message is appended,
+  /// and again when the response (or error bubble) arrives.
+  Future<void> sendText(String text) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty || _isResponding) return;
+
+    _appendMessage(CodifyChatMessage.user(text: trimmed, createdAt: _clock()));
+    _isResponding = true;
+    notifyListeners();
+
+    CodifyChatMessage reply;
+    try {
+      reply = await _responder(trimmed);
+    } catch (error, stackTrace) {
+      // Surface the failure to the developer (console / FlutterError.onError /
+      // crash reporters) — the catch must not swallow it silently — then show
+      // the user a generic error bubble.
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: 'codifyiq_core_components',
+          context: ErrorDescription('while awaiting an AiChatResponder reply'),
+        ),
+      );
+      reply = CodifyChatMessage.error(
+        text: 'Something went wrong. Please try again.',
+      );
+    }
+
+    // The controller may have been disposed while the responder was in flight
+    // (e.g. the user navigated away). Bail before mutating or notifying — a
+    // notifyListeners() after dispose() throws.
+    if (_isDisposed) return;
+    // Stamp the reply on the controller's clock so the whole timeline shares
+    // one time source (and honours an injected test clock).
+    _appendMessage(reply.copyWith(createdAt: _clock()));
+    _isResponding = false;
+    notifyListeners();
+  }
+
+  /// Appends [message] to the timeline directly, without a backend round-trip.
+  ///
+  /// Useful for seeding the conversation or injecting messages from another
+  /// source.
+  void addMessage(CodifyChatMessage message) {
+    _appendMessage(message);
+    notifyListeners();
+  }
+
+  /// Stamps `seenAt` on the message with [id] the first time it is seen.
+  ///
+  /// No-op when the message is absent or already seen, so it is safe to call
+  /// repeatedly from a visibility callback.
+  void markSeen(String id) {
+    // Visibility callbacks can arrive after the controller is disposed.
+    if (_isDisposed) return;
+    final index = _messages.indexWhere((m) => m.id == id);
+    if (index == -1 || _messages[index].seenAt != null) return;
+    final updated = _messages[index].copyWith(seenAt: _clock());
+    _messages[index] = updated;
+    _messagesById[updated.id] = updated;
+    notifyListeners();
+  }
+
+  /// Removes every message from the timeline.
+  void clear() {
+    if (_messages.isEmpty) return;
+    _messages.clear();
+    _messagesById.clear();
+    notifyListeners();
+  }
+
+  /// Appends [message] to the timeline and keeps the id index in sync.
+  void _appendMessage(CodifyChatMessage message) {
+    _messages.add(message);
+    _messagesById[message.id] = message;
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+}

--- a/codifyiq_core_components/lib/widgets/ai_chat/ai_chat_controller.dart
+++ b/codifyiq_core_components/lib/widgets/ai_chat/ai_chat_controller.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter_chat_core/flutter_chat_core.dart';
 
 import 'codify_chat_message.dart';
+import 'flyer_chat_mapper.dart';
 
 /// Performs the backend round-trip for a chat turn.
 ///
 /// Given the user's [prompt], returns the AI's reply as a [CodifyChatMessage]
 /// — typically [CodifyChatMessage.ai] for text, but may also be a
-/// [CodifyChatMessage.pdf] or [CodifyChatMessage.image] placeholder. Throwing
-/// from the responder makes [AiChatController] append an error bubble.
+/// [CodifyChatMessage.pdf] or [CodifyChatMessage.image]. Throwing from the
+/// responder makes [AiChatController] append an error bubble.
 ///
 /// The package ships no networking layer: consumers wire the responder to
 /// their own API client, SDK, or mock.
@@ -16,8 +18,9 @@ typedef AiChatResponder = Future<CodifyChatMessage> Function(String prompt);
 /// State manager for an AI chat conversation.
 ///
 /// Owns the ordered message timeline and the request lifecycle for a single
-/// chat. `AiChatScreen` listens to this controller and rebuilds when it
-/// changes; the controller is otherwise UI-agnostic.
+/// chat. It keeps a Flyer Chat [ChatController] ([chatController]) in sync with
+/// the timeline so `AiChatScreen` can hand it straight to the Flyer `Chat`
+/// widget; the controller is otherwise UI-agnostic.
 ///
 /// Typical flow:
 ///
@@ -26,8 +29,7 @@ typedef AiChatResponder = Future<CodifyChatMessage> Function(String prompt);
 /// 2. On success the responder's message is appended; on failure an error
 ///    bubble is appended instead.
 /// 3. [markSeen] stamps a message's `seenAt` the first time it becomes
-///    visible — `AiChatScreen` calls this from Flyer Chat's visibility
-///    callback.
+///    visible — `AiChatScreen` calls this from a visibility callback.
 ///
 /// Pass a custom [clock] to override [DateTime.now] in tests.
 class AiChatController extends ChangeNotifier {
@@ -43,6 +45,11 @@ class AiChatController extends ChangeNotifier {
        _clock = clock ?? DateTime.now,
        _messages = List<CodifyChatMessage>.of(
          initialMessages ?? const <CodifyChatMessage>[],
+       ),
+       chatController = InMemoryChatController(
+         messages: (initialMessages ?? const <CodifyChatMessage>[])
+             .map(toFlyerMessage)
+             .toList(),
        ) {
     for (final message in _messages) {
       _messagesById[message.id] = message;
@@ -52,18 +59,41 @@ class AiChatController extends ChangeNotifier {
   final AiChatResponder _responder;
   final DateTime Function() _clock;
   final List<CodifyChatMessage> _messages;
-  // Id index kept in sync with [_messages] so [messageById] is O(1); it is
-  // called once per custom-message bubble on every rebuild.
+  // Id index kept in sync with [_messages] so lookups by id ([messageById],
+  // [markSeen]) are O(1) rather than a linear scan.
   final Map<String, CodifyChatMessage> _messagesById =
       <String, CodifyChatMessage>{};
+  // Cached unmodifiable view of [_messages], rebuilt lazily after a mutation.
+  List<CodifyChatMessage>? _cachedMessages;
   bool _isResponding = false;
   bool _isDisposed = false;
+  // Bumped by [clear]. A [sendText] whose responder was in flight when the
+  // conversation was cleared compares against this and drops its stale reply.
+  int _generation = 0;
+
+  /// The Flyer Chat controller mirroring this timeline.
+  ///
+  /// Exposed so `AiChatScreen` can pass it to the Flyer `Chat` widget;
+  /// consumers drive the chat through [sendText] / [addMessage] and do not
+  /// touch this directly. Kept in sync by every mutation below.
+  ///
+  /// The mutation methods call `insertMessage` / `updateMessage` /
+  /// `setMessages` without `await`. [InMemoryChatController] runs those
+  /// synchronously (no real `await` in their bodies), so call order is
+  /// preserved; swapping in a different [ChatController] implementation
+  /// would need re-verifying.
+  @internal
+  final ChatController chatController;
 
   /// The conversation timeline, oldest first. Unmodifiable.
-  List<CodifyChatMessage> get messages => List.unmodifiable(_messages);
+  ///
+  /// The view is cached and reused until the next mutation, so repeated reads
+  /// do not each allocate a copy.
+  List<CodifyChatMessage> get messages =>
+      _cachedMessages ??= List.unmodifiable(_messages);
 
   /// Whether a backend request is currently in flight. While `true`,
-  /// `AiChatScreen` shows the loading indicator and ignores further sends.
+  /// `AiChatScreen` shows the loading indicator and blocks further sends.
   bool get isResponding => _isResponding;
 
   /// Whether the timeline has no messages.
@@ -81,6 +111,7 @@ class AiChatController extends ChangeNotifier {
     final trimmed = text.trim();
     if (trimmed.isEmpty || _isResponding) return;
 
+    final generation = _generation;
     _appendMessage(CodifyChatMessage.user(text: trimmed, createdAt: _clock()));
     _isResponding = true;
     notifyListeners();
@@ -105,10 +136,10 @@ class AiChatController extends ChangeNotifier {
       );
     }
 
-    // The controller may have been disposed while the responder was in flight
-    // (e.g. the user navigated away). Bail before mutating or notifying — a
-    // notifyListeners() after dispose() throws.
-    if (_isDisposed) return;
+    // Bail if, while the responder was in flight, the controller was disposed
+    // (e.g. the user navigated away) or the conversation was cleared — the
+    // reply is stale either way. A notifyListeners() after dispose() throws.
+    if (_isDisposed || generation != _generation) return;
     // Stamp the reply on the controller's clock so the whole timeline shares
     // one time source (and honours an injected test clock).
     _appendMessage(reply.copyWith(createdAt: _clock()));
@@ -132,31 +163,53 @@ class AiChatController extends ChangeNotifier {
   void markSeen(String id) {
     // Visibility callbacks can arrive after the controller is disposed.
     if (_isDisposed) return;
-    final index = _messages.indexWhere((m) => m.id == id);
-    if (index == -1 || _messages[index].seenAt != null) return;
-    final updated = _messages[index].copyWith(seenAt: _clock());
+    // O(1) lookup + early-out: most visibility ticks are no-ops because the
+    // message is absent or already seen.
+    final current = _messagesById[id];
+    if (current == null || current.seenAt != null) return;
+    // Only a genuine first-seen reaches here; locating the list slot for the
+    // in-place update is O(n), but runs at most once per message.
+    final index = _messages.indexOf(current);
+    if (index == -1) return;
+    final updated = current.copyWith(seenAt: _clock());
     _messages[index] = updated;
-    _messagesById[updated.id] = updated;
+    _messagesById[id] = updated;
+    _cachedMessages = null;
+    chatController.updateMessage(
+      toFlyerMessage(current),
+      toFlyerMessage(updated),
+    );
     notifyListeners();
   }
 
   /// Removes every message from the timeline.
+  ///
+  /// If a reply is in flight it is abandoned: [isResponding] is reset now and
+  /// the late reply is dropped on arrival rather than appended to the emptied
+  /// timeline.
   void clear() {
-    if (_messages.isEmpty) return;
+    if (_messages.isEmpty && !_isResponding) return;
     _messages.clear();
     _messagesById.clear();
+    _cachedMessages = null;
+    _isResponding = false;
+    _generation++;
+    chatController.setMessages(const <Message>[]);
     notifyListeners();
   }
 
-  /// Appends [message] to the timeline and keeps the id index in sync.
+  /// Appends [message] to the timeline, the id index, and the Flyer controller.
   void _appendMessage(CodifyChatMessage message) {
     _messages.add(message);
     _messagesById[message.id] = message;
+    _cachedMessages = null;
+    chatController.insertMessage(toFlyerMessage(message));
   }
 
   @override
   void dispose() {
     _isDisposed = true;
+    chatController.dispose();
     super.dispose();
   }
 }

--- a/codifyiq_core_components/lib/widgets/ai_chat/ai_chat_screen.dart
+++ b/codifyiq_core_components/lib/widgets/ai_chat/ai_chat_screen.dart
@@ -1,0 +1,545 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+import 'package:flutter_chat_ui/flutter_chat_ui.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+import '../ai_progress_indicator.dart';
+import 'ai_chat_controller.dart';
+import 'codify_chat_message.dart';
+import 'flyer_chat_mapper.dart';
+
+/// An embeddable AI chat experience for the CodifyIQ design system.
+///
+/// [AiChatScreen] wraps the Flyer Chat (`flutter_chat_ui`) `Chat` widget — it
+/// does not reimplement the scrollable timeline, message bubbles, auto-scroll,
+/// or input bar — and re-skins it with Material 3 colors from the ambient
+/// [Theme]. It renders only the chat area, with no [Scaffold] or [AppBar], so
+/// it can be embedded anywhere.
+///
+/// Drive it with an [AiChatController]: the controller owns the timeline and
+/// the backend round-trip, and this widget rebuilds when it changes.
+///
+/// ## MVP behavior
+///
+/// - Text messaging with a multiline input and a send button (Flyer-provided)
+///   that stays visible, grayed out while the field is empty or a reply is in
+///   flight. Sending is blocked while a reply is in flight, and the draft text
+///   is preserved rather than cleared.
+/// - AI replies render as Markdown (headings, bold, lists, code, links); user
+///   messages render as plain text.
+/// - On wide (desktop) viewports the conversation is centered in a column
+///   capped at [maxContentWidth].
+/// - Image messages render inline via Flyer Chat. Tapping one opens the
+///   built-in zoom gallery by default, or — with [enableImageGallery] set to
+///   `false` — is forwarded to [onMessageTap] for a custom viewer, exactly
+///   like PDF.
+/// - PDF messages render as tappable file rows; the tap is forwarded to
+///   [onMessageTap] so the host can open its own PDF viewer.
+/// - A `+` attachment button opens an "Add image / Add PDF" menu whenever
+///   [onAttachImage] and/or [onAttachPdf] are provided; it is hidden when both
+///   are null. The host app performs the actual file picking.
+/// - While a reply is awaited, an [AiProgressIndicator] is shown in Flyer's
+///   typing-indicator slot.
+/// - A message's `seenAt` is stamped automatically the first time it scrolls
+///   into view.
+class AiChatScreen extends StatefulWidget {
+  /// Creates an [AiChatScreen].
+  const AiChatScreen({
+    super.key,
+    required this.controller,
+    this.onSendMessage,
+    this.onMessageTap,
+    this.enableImageGallery = true,
+    this.onAttachImage,
+    this.onAttachPdf,
+    this.inputHint,
+    this.emptyState,
+    this.maxContentWidth = 760,
+  });
+
+  /// Owns the message timeline, send lifecycle, and `seenAt` updates.
+  final AiChatController controller;
+
+  /// Called with the raw text the moment the user taps send, just before the
+  /// controller dispatches it. Purely observational — the controller still
+  /// performs the send.
+  final void Function(String text)? onSendMessage;
+
+  /// Called when the user taps a message bubble.
+  ///
+  /// The PDF/image viewer integration hooks in here: inspect
+  /// [CodifyChatMessage.kind] and [CodifyChatMessage.sourceUri] to open the
+  /// appropriate viewer. Always fires for PDF taps, and for image taps too —
+  /// see [enableImageGallery].
+  final void Function(CodifyChatMessage message)? onMessageTap;
+
+  /// Whether tapping an image opens Flyer Chat's built-in full-screen,
+  /// pinch-to-zoom gallery.
+  ///
+  /// Defaults to `true`. Set to `false` to suppress the built-in gallery so
+  /// an image tap is delivered *only* through [onMessageTap] — wire that to
+  /// your own image viewer, the same way PDF taps are handled. [onMessageTap]
+  /// fires regardless of this flag.
+  final bool enableImageGallery;
+
+  /// Called when the user picks "Add image" from the `+` attachment menu.
+  ///
+  /// The package ships no file picker: the host app opens an image picker and
+  /// adds the resulting message itself (e.g. via [AiChatController.addMessage]
+  /// with [CodifyChatMessage.image]). When both this and [onAttachPdf] are
+  /// null, the attachment button is hidden.
+  final VoidCallback? onAttachImage;
+
+  /// Called when the user picks "Add PDF" from the `+` attachment menu.
+  ///
+  /// The host app opens the document picker and adds the resulting message
+  /// itself. When both this and [onAttachImage] are null, the attachment
+  /// button is hidden.
+  final VoidCallback? onAttachPdf;
+
+  /// Optional placeholder text for the input field.
+  final String? inputHint;
+
+  /// Optional widget shown when the timeline is empty.
+  final Widget? emptyState;
+
+  /// Maximum width of the chat column.
+  ///
+  /// On wide (desktop) viewports the timeline and input bar are centered and
+  /// capped at this width so the conversation does not sprawl across the
+  /// screen; the side gutters are painted in a dimmed surface tone so the
+  /// column reads as a contained area. Defaults to `760`. Pass `null` to let
+  /// the chat fill all available width (no gutters).
+  final double? maxContentWidth;
+
+  @override
+  State<AiChatScreen> createState() => _AiChatScreenState();
+}
+
+class _AiChatScreenState extends State<AiChatScreen> {
+  // Held so the send button can react to the input's contents. Flyer's Input
+  // widget exposes no send-button builder, but it does accept an external text
+  // controller and a themed send icon — together those let the icon gray
+  // itself out while the field is empty.
+  //
+  // Deliberately NOT disposed here: flutter_chat_ui's Input takes ownership of
+  // the controller passed via InputOptions.textEditingController and disposes
+  // it itself. Disposing it again would double-dispose and crash.
+  final InputTextFieldController _inputController = InputTextFieldController();
+
+  // Anchors the attachment menu to the `+` button. The key rides on the
+  // themed attachment icon, which Flyer renders inside the button.
+  final GlobalKey _attachButtonKey = GlobalKey();
+
+  /// Whether at least one attachment callback is wired — drives whether the
+  /// `+` button is shown at all.
+  bool get _attachEnabled =>
+      widget.onAttachImage != null || widget.onAttachPdf != null;
+
+  /// Opens the "Add image / Add PDF" menu anchored to the `+` button, then
+  /// dispatches the host callback for the chosen option.
+  Future<void> _showAttachMenu() async {
+    // With only one attachment type wired, skip the menu and open that picker
+    // directly. (_showAttachMenu is only reachable when at least one callback
+    // is set, so the other is guaranteed non-null past these guards.)
+    if (widget.onAttachPdf == null) {
+      widget.onAttachImage?.call();
+      return;
+    }
+    if (widget.onAttachImage == null) {
+      widget.onAttachPdf?.call();
+      return;
+    }
+
+    final buttonContext = _attachButtonKey.currentContext;
+    if (buttonContext == null) return;
+    final button = buttonContext.findRenderObject() as RenderBox;
+    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
+    final position = RelativeRect.fromRect(
+      Rect.fromPoints(
+        button.localToGlobal(Offset.zero, ancestor: overlay),
+        button.localToGlobal(
+          button.size.bottomRight(Offset.zero),
+          ancestor: overlay,
+        ),
+      ),
+      Offset.zero & overlay.size,
+    );
+
+    final selected = await showMenu<CodifyChatMessageKind>(
+      context: context,
+      position: position,
+      items: const [
+        PopupMenuItem<CodifyChatMessageKind>(
+          value: CodifyChatMessageKind.image,
+          child: _AttachMenuItem(
+            icon: Icons.image_outlined,
+            label: 'Add image',
+          ),
+        ),
+        PopupMenuItem<CodifyChatMessageKind>(
+          value: CodifyChatMessageKind.pdf,
+          child: _AttachMenuItem(
+            icon: Icons.picture_as_pdf_outlined,
+            label: 'Add PDF',
+          ),
+        ),
+      ],
+    );
+
+    switch (selected) {
+      case CodifyChatMessageKind.image:
+        widget.onAttachImage?.call();
+      case CodifyChatMessageKind.pdf:
+        widget.onAttachPdf?.call();
+      case CodifyChatMessageKind.text:
+      case CodifyChatMessageKind.error:
+      case null:
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListenableBuilder(
+      listenable: widget.controller,
+      builder: (context, _) {
+        final Widget chat = Chat(
+          messages: toFlyerMessages(widget.controller.messages),
+          user: userAuthor,
+          theme: _buildChatTheme(theme),
+          l10n: ChatL10nEn(
+            inputPlaceholder: widget.inputHint ?? 'Message',
+            attachmentButtonAccessibilityLabel: 'Attach',
+          ),
+          emptyState: widget.emptyState,
+          // When the host opts out, an image tap skips Flyer's gallery and is
+          // delivered through onMessageTap only — symmetric with PDF.
+          disableImageGallery: !widget.enableImageGallery,
+          // A null onAttachmentPressed makes Flyer hide the `+` button, so it
+          // only appears when the host wired up at least one attach callback.
+          onAttachmentPressed: _attachEnabled ? _showAttachMenu : null,
+          inputOptions: InputOptions(
+            textEditingController: _inputController,
+            // Keep the send button on screen at all times; _buildChatTheme
+            // grays its icon out while the field is empty or a reply is in
+            // flight.
+            sendButtonVisibilityMode: SendButtonVisibilityMode.always,
+            // Clear the field ourselves (in onSendPressed) only on an accepted
+            // send — so a send attempted while responding keeps the draft.
+            inputClearMode: InputClearMode.never,
+          ),
+          onSendPressed: (partialText) {
+            // Block sends while a reply is in flight. Returning early here
+            // also skips the clear below, so the user's draft is preserved.
+            if (widget.controller.isResponding) return;
+            widget.onSendMessage?.call(partialText.text);
+            widget.controller.sendText(partialText.text);
+            _inputController.clear();
+          },
+          onMessageTap: (_, message) {
+            final tapped = widget.controller.messageById(message.id);
+            if (tapped != null) widget.onMessageTap?.call(tapped);
+          },
+          onMessageVisibilityChanged: (message, visible) {
+            if (visible) widget.controller.markSeen(message.id);
+          },
+          textMessageBuilder:
+              (message, {required messageWidth, required showName}) {
+                return _TextMessageContent(
+                  message: message,
+                  maxWidth: messageWidth.toDouble(),
+                );
+              },
+          customMessageBuilder: (message, {required int messageWidth}) {
+            return _CustomMessageBubble(
+              message: widget.controller.messageById(message.id),
+              maxWidth: messageWidth.toDouble(),
+            );
+          },
+          typingIndicatorOptions: TypingIndicatorOptions(
+            typingUsers: widget.controller.isResponding
+                ? const <types.User>[aiAuthor]
+                : const <types.User>[],
+            customTypingIndicatorBuilder:
+                ({
+                  required context,
+                  required bubbleAlignment,
+                  required options,
+                  required indicatorOnScrollStatus,
+                }) => const _ThinkingIndicator(),
+          ),
+        );
+
+        final maxWidth = widget.maxContentWidth;
+        if (maxWidth == null) return chat;
+        // Center the conversation in a capped column on wide (desktop)
+        // viewports. The gutters take a dimmed surface tone so the column
+        // reads as an intentional, contained area rather than content
+        // floating in empty space. On narrow screens the column fills the
+        // width and the gutters are not visible.
+        return ColoredBox(
+          color: theme.colorScheme.surfaceContainer,
+          child: Center(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: maxWidth),
+              child: chat,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// Derives a Flyer [ChatTheme] from the ambient Material 3 [ThemeData] so
+  /// the chat matches the surrounding CodifyIQ app.
+  ChatTheme _buildChatTheme(ThemeData theme) {
+    final colorScheme = theme.colorScheme;
+    final bodyStyle = theme.textTheme.bodyLarge ?? const TextStyle();
+    return DefaultChatTheme(
+      backgroundColor: colorScheme.surface,
+      primaryColor: colorScheme.primary,
+      secondaryColor: colorScheme.surfaceContainerHighest,
+      sentMessageBodyTextStyle: bodyStyle.copyWith(
+        color: colorScheme.onPrimary,
+      ),
+      receivedMessageBodyTextStyle: bodyStyle.copyWith(
+        color: colorScheme.onSurface,
+      ),
+      emptyChatPlaceholderTextStyle: bodyStyle.copyWith(
+        color: colorScheme.onSurfaceVariant,
+      ),
+      dateDividerTextStyle: (theme.textTheme.labelSmall ?? const TextStyle())
+          .copyWith(color: colorScheme.onSurfaceVariant),
+      inputBackgroundColor: colorScheme.surfaceContainerHighest,
+      inputSurfaceTintColor: colorScheme.surfaceTint,
+      inputTextColor: colorScheme.onSurface,
+      inputTextCursorColor: colorScheme.primary,
+      inputContainerDecoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+      ),
+      receivedMessageDocumentIconColor: colorScheme.primary,
+      sentMessageDocumentIconColor: colorScheme.onPrimary,
+      sendButtonIcon: _SendButtonIcon(
+        controller: _inputController,
+        isResponding: widget.controller.isResponding,
+      ),
+      // The key rides on the icon so _showAttachMenu can anchor the menu to
+      // the `+` button's on-screen position.
+      attachmentButtonIcon: KeyedSubtree(
+        key: _attachButtonKey,
+        child: Icon(Icons.add, color: colorScheme.onSurfaceVariant),
+      ),
+    );
+  }
+}
+
+/// A single row in the attachment menu — a leading icon and a label.
+class _AttachMenuItem extends StatelessWidget {
+  const _AttachMenuItem({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, size: 22, color: Theme.of(context).colorScheme.onSurface),
+        const SizedBox(width: 12),
+        Text(label),
+      ],
+    );
+  }
+}
+
+/// Renders a text message inside Flyer's bubble.
+///
+/// AI replies are rendered as Markdown — AI backends typically return Markdown
+/// — while user messages stay plain text.
+class _TextMessageContent extends StatelessWidget {
+  const _TextMessageContent({required this.message, required this.maxWidth});
+
+  final types.TextMessage message;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isFromAi = message.author.id == aiAuthor.id;
+    final bodyStyle = (theme.textTheme.bodyLarge ?? const TextStyle()).copyWith(
+      color: isFromAi
+          ? theme.colorScheme.onSurface
+          : theme.colorScheme.onPrimary,
+    );
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        child: isFromAi
+            ? GptMarkdown(message.text, style: bodyStyle)
+            : Text(message.text, style: bodyStyle),
+      ),
+    );
+  }
+}
+
+/// Renders the placeholder / error bubbles for non-text messages.
+///
+/// The content sits inside Flyer's received-message bubble (painted with
+/// [ChatTheme.secondaryColor]); the error variant paints its own background
+/// to override that color.
+class _CustomMessageBubble extends StatelessWidget {
+  const _CustomMessageBubble({required this.message, required this.maxWidth});
+
+  final CodifyChatMessage? message;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final message = this.message;
+    if (message == null) return const SizedBox.shrink();
+
+    switch (message.kind) {
+      case CodifyChatMessageKind.pdf:
+        return _PlaceholderBubble(
+          maxWidth: maxWidth,
+          text: '📄 PDF message (no file attached).',
+        );
+      case CodifyChatMessageKind.image:
+        return _PlaceholderBubble(
+          maxWidth: maxWidth,
+          text: '🖼️ Image message (no file attached).',
+        );
+      case CodifyChatMessageKind.error:
+        return _ErrorBubble(maxWidth: maxWidth, text: message.text);
+      case CodifyChatMessageKind.text:
+        // Text messages never reach the custom builder.
+        return const SizedBox.shrink();
+    }
+  }
+}
+
+/// A neutral bubble used for not-yet-supported PDF/image responses.
+class _PlaceholderBubble extends StatelessWidget {
+  const _PlaceholderBubble({required this.text, required this.maxWidth});
+
+  final String text;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        child: Text(
+          text,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A bubble that surfaces a failed chat turn in the theme's error colors.
+class _ErrorBubble extends StatelessWidget {
+  const _ErrorBubble({required this.text, required this.maxWidth});
+
+  final String text;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      child: Container(
+        color: theme.colorScheme.errorContainer,
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 20,
+              color: theme.colorScheme.onErrorContainer,
+            ),
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                text,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The loading indicator shown in Flyer's typing-indicator slot while the
+/// backend request is in flight. Reuses the package's [AiProgressIndicator].
+class _ThinkingIndicator extends StatelessWidget {
+  const _ThinkingIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(24, 8, 24, 16),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: AiProgressIndicator(
+          text: 'Thinking…',
+          textStyle: theme.textTheme.bodyMedium,
+        ),
+      ),
+    );
+  }
+}
+
+/// The send-button icon, tinted to reflect whether a send is currently
+/// possible.
+///
+/// Flyer's `Input` always renders the send button (see
+/// [SendButtonVisibilityMode.always]); this widget listens to the input's
+/// [TextEditingController] and grays the icon out while the field is empty or
+/// a reply is in flight ([isResponding]), restoring the primary color only
+/// when the user has typed something and no request is pending.
+class _SendButtonIcon extends StatelessWidget {
+  const _SendButtonIcon({required this.controller, required this.isResponding});
+
+  final TextEditingController controller;
+  final bool isResponding;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (context, _) {
+        final canSend = !isResponding && controller.text.trim().isNotEmpty;
+        return Icon(
+          Icons.send_rounded,
+          color: canSend
+              ? colorScheme.primary
+              : colorScheme.onSurface.withValues(alpha: 0.38),
+        );
+      },
+    );
+  }
+}

--- a/codifyiq_core_components/lib/widgets/ai_chat/ai_chat_screen.dart
+++ b/codifyiq_core_components/lib/widgets/ai_chat/ai_chat_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+import 'package:flutter_chat_core/flutter_chat_core.dart';
 import 'package:flutter_chat_ui/flutter_chat_ui.dart';
-import 'package:gpt_markdown/gpt_markdown.dart';
+import 'package:flyer_chat_file_message/flyer_chat_file_message.dart';
+import 'package:flyer_chat_image_message/flyer_chat_image_message.dart';
+import 'package:flyer_chat_text_message/flyer_chat_text_message.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
 import '../ai_progress_indicator.dart';
 import 'ai_chat_controller.dart';
@@ -10,38 +13,29 @@ import 'flyer_chat_mapper.dart';
 
 /// An embeddable AI chat experience for the CodifyIQ design system.
 ///
-/// [AiChatScreen] wraps the Flyer Chat (`flutter_chat_ui`) `Chat` widget — it
-/// does not reimplement the scrollable timeline, message bubbles, auto-scroll,
-/// or input bar — and re-skins it with Material 3 colors from the ambient
-/// [Theme]. It renders only the chat area, with no [Scaffold] or [AppBar], so
-/// it can be embedded anywhere.
+/// [AiChatScreen] wraps the Flyer Chat (`flutter_chat_ui` v2) `Chat` widget,
+/// re-skinned from the ambient Material 3 [Theme]. It renders only the chat
+/// area — no [Scaffold] or [AppBar] — so it can be embedded anywhere.
 ///
-/// Drive it with an [AiChatController]: the controller owns the timeline and
-/// the backend round-trip, and this widget rebuilds when it changes.
+/// Drive it with an [AiChatController]: the controller owns the timeline, the
+/// backend round-trip, and the Flyer `ChatController` this widget renders.
 ///
-/// ## MVP behavior
+/// ## Behaviour
 ///
-/// - Text messaging with a multiline input and a send button (Flyer-provided)
-///   that stays visible, grayed out while the field is empty or a reply is in
-///   flight. Sending is blocked while a reply is in flight, and the draft text
-///   is preserved rather than cleared.
-/// - AI replies render as Markdown (headings, bold, lists, code, links); user
-///   messages render as plain text.
-/// - On wide (desktop) viewports the conversation is centered in a column
-///   capped at [maxContentWidth].
-/// - Image messages render inline via Flyer Chat. Tapping one opens the
-///   built-in zoom gallery by default, or — with [enableImageGallery] set to
-///   `false` — is forwarded to [onMessageTap] for a custom viewer, exactly
-///   like PDF.
-/// - PDF messages render as tappable file rows; the tap is forwarded to
-///   [onMessageTap] so the host can open its own PDF viewer.
+/// - Text messaging with a multiline composer. Messages render as Markdown;
+///   the send button is grayed out while the field is empty or a reply is in
+///   flight, and sending is blocked (the draft is preserved) during a reply.
+/// - Image messages render inline; PDF messages render as tappable file rows.
+///   Taps are forwarded to [onMessageTap] so the host can open its own viewer.
 /// - A `+` attachment button opens an "Add image / Add PDF" menu whenever
 ///   [onAttachImage] and/or [onAttachPdf] are provided; it is hidden when both
 ///   are null. The host app performs the actual file picking.
-/// - While a reply is awaited, an [AiProgressIndicator] is shown in Flyer's
-///   typing-indicator slot.
-/// - A message's `seenAt` is stamped automatically the first time it scrolls
-///   into view.
+/// - While a reply is awaited, an [AiProgressIndicator] is shown above the
+///   composer.
+/// - An AI message's `seenAt` is stamped automatically the first time it
+///   scrolls into view.
+/// - On wide (desktop) viewports the conversation is centered in a column
+///   capped at [maxContentWidth].
 class AiChatScreen extends StatefulWidget {
   /// Creates an [AiChatScreen].
   const AiChatScreen({
@@ -49,7 +43,6 @@ class AiChatScreen extends StatefulWidget {
     required this.controller,
     this.onSendMessage,
     this.onMessageTap,
-    this.enableImageGallery = true,
     this.onAttachImage,
     this.onAttachPdf,
     this.inputHint,
@@ -61,26 +54,15 @@ class AiChatScreen extends StatefulWidget {
   final AiChatController controller;
 
   /// Called with the raw text the moment the user taps send, just before the
-  /// controller dispatches it. Purely observational — the controller still
-  /// performs the send.
+  /// controller dispatches it. Purely observational.
   final void Function(String text)? onSendMessage;
 
   /// Called when the user taps a message bubble.
   ///
   /// The PDF/image viewer integration hooks in here: inspect
   /// [CodifyChatMessage.kind] and [CodifyChatMessage.sourceUri] to open the
-  /// appropriate viewer. Always fires for PDF taps, and for image taps too —
-  /// see [enableImageGallery].
+  /// appropriate viewer.
   final void Function(CodifyChatMessage message)? onMessageTap;
-
-  /// Whether tapping an image opens Flyer Chat's built-in full-screen,
-  /// pinch-to-zoom gallery.
-  ///
-  /// Defaults to `true`. Set to `false` to suppress the built-in gallery so
-  /// an image tap is delivered *only* through [onMessageTap] — wire that to
-  /// your own image viewer, the same way PDF taps are handled. [onMessageTap]
-  /// fires regardless of this flag.
-  final bool enableImageGallery;
 
   /// Called when the user picks "Add image" from the `+` attachment menu.
   ///
@@ -97,7 +79,7 @@ class AiChatScreen extends StatefulWidget {
   /// button is hidden.
   final VoidCallback? onAttachPdf;
 
-  /// Optional placeholder text for the input field.
+  /// Optional placeholder text for the composer input field.
   final String? inputHint;
 
   /// Optional widget shown when the timeline is empty.
@@ -105,7 +87,7 @@ class AiChatScreen extends StatefulWidget {
 
   /// Maximum width of the chat column.
   ///
-  /// On wide (desktop) viewports the timeline and input bar are centered and
+  /// On wide (desktop) viewports the timeline and composer are centered and
   /// capped at this width so the conversation does not sprawl across the
   /// screen; the side gutters are painted in a dimmed surface tone so the
   /// column reads as a contained area. Defaults to `760`. Pass `null` to let
@@ -117,18 +99,12 @@ class AiChatScreen extends StatefulWidget {
 }
 
 class _AiChatScreenState extends State<AiChatScreen> {
-  // Held so the send button can react to the input's contents. Flyer's Input
-  // widget exposes no send-button builder, but it does accept an external text
-  // controller and a themed send icon — together those let the icon gray
-  // itself out while the field is empty.
-  //
-  // Deliberately NOT disposed here: flutter_chat_ui's Input takes ownership of
-  // the controller passed via InputOptions.textEditingController and disposes
-  // it itself. Disposing it again would double-dispose and crash.
-  final InputTextFieldController _inputController = InputTextFieldController();
+  // Owned here and disposed in dispose(): Flyer's v2 Composer does NOT dispose
+  // a controller passed in via `textEditingController`.
+  final TextEditingController _composerController = TextEditingController();
 
   // Anchors the attachment menu to the `+` button. The key rides on the
-  // themed attachment icon, which Flyer renders inside the button.
+  // composer's attachment icon.
   final GlobalKey _attachButtonKey = GlobalKey();
 
   /// Whether at least one attachment callback is wired — drives whether the
@@ -136,12 +112,112 @@ class _AiChatScreenState extends State<AiChatScreen> {
   bool get _attachEnabled =>
       widget.onAttachImage != null || widget.onAttachPdf != null;
 
+  @override
+  void dispose() {
+    _composerController.dispose();
+    super.dispose();
+  }
+
+  void _handleSend(String text) {
+    // Block sends while a reply is in flight; returning early also skips the
+    // clear below (inputClearMode is `never`), so the draft is preserved.
+    if (widget.controller.isResponding) return;
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+    widget.onSendMessage?.call(trimmed);
+    widget.controller.sendText(trimmed);
+    _composerController.clear();
+  }
+
+  void _handleMessageTap(
+    BuildContext context,
+    Message message, {
+    required int index,
+    required TapUpDetails details,
+  }) {
+    final tapped = widget.controller.messageById(message.id);
+    if (tapped != null) widget.onMessageTap?.call(tapped);
+  }
+
+  /// Wraps a message widget so an AI message's `seenAt` is stamped the first
+  /// time it scrolls into view (v2 has no built-in visibility callback).
+  ///
+  /// The user's own messages are not tracked — marking them "seen" is
+  /// meaningless and would surface a misleading status indicator.
+  Widget _messageItem(String id, bool isSentByMe, Widget child) {
+    if (isSentByMe) return child;
+    return VisibilityDetector(
+      key: ValueKey('codify-chat-seen-$id'),
+      onVisibilityChanged: (info) {
+        if (info.visibleFraction > 0) widget.controller.markSeen(id);
+      },
+      child: child,
+    );
+  }
+
+  Widget _buildTextMessage(
+    BuildContext context,
+    TextMessage message,
+    int index, {
+    required bool isSentByMe,
+    MessageGroupStatus? groupStatus,
+  }) => _messageItem(
+    message.id,
+    isSentByMe,
+    FlyerChatTextMessage(message: message, index: index),
+  );
+
+  Widget _buildImageMessage(
+    BuildContext context,
+    ImageMessage message,
+    int index, {
+    required bool isSentByMe,
+    MessageGroupStatus? groupStatus,
+  }) => _messageItem(
+    message.id,
+    isSentByMe,
+    FlyerChatImageMessage(message: message, index: index),
+  );
+
+  Widget _buildFileMessage(
+    BuildContext context,
+    FileMessage message,
+    int index, {
+    required bool isSentByMe,
+    MessageGroupStatus? groupStatus,
+  }) => _messageItem(
+    message.id,
+    isSentByMe,
+    FlyerChatFileMessage(message: message, index: index),
+  );
+
+  Widget _buildCustomMessage(
+    BuildContext context,
+    CustomMessage message,
+    int index, {
+    required bool isSentByMe,
+    MessageGroupStatus? groupStatus,
+  }) => _messageItem(
+    message.id,
+    isSentByMe,
+    _CustomMessageBubble(message: widget.controller.messageById(message.id)),
+  );
+
+  Widget _buildEmptyState(BuildContext context) => widget.emptyState!;
+
+  Widget _buildComposer(BuildContext context) => _ChatComposer(
+    controller: widget.controller,
+    textController: _composerController,
+    attachButtonKey: _attachButtonKey,
+    hintText: widget.inputHint ?? 'Message',
+  );
+
   /// Opens the "Add image / Add PDF" menu anchored to the `+` button, then
   /// dispatches the host callback for the chosen option.
   Future<void> _showAttachMenu() async {
     // With only one attachment type wired, skip the menu and open that picker
-    // directly. (_showAttachMenu is only reachable when at least one callback
-    // is set, so the other is guaranteed non-null past these guards.)
+    // directly. (This is only reachable when at least one callback is set, so
+    // the other is guaranteed non-null past these guards.)
     if (widget.onAttachPdf == null) {
       widget.onAttachImage?.call();
       return;
@@ -202,135 +278,96 @@ class _AiChatScreenState extends State<AiChatScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return ListenableBuilder(
-      listenable: widget.controller,
-      builder: (context, _) {
-        final Widget chat = Chat(
-          messages: toFlyerMessages(widget.controller.messages),
-          user: userAuthor,
-          theme: _buildChatTheme(theme),
-          l10n: ChatL10nEn(
-            inputPlaceholder: widget.inputHint ?? 'Message',
-            attachmentButtonAccessibilityLabel: 'Attach',
-          ),
-          emptyState: widget.emptyState,
-          // When the host opts out, an image tap skips Flyer's gallery and is
-          // delivered through onMessageTap only — symmetric with PDF.
-          disableImageGallery: !widget.enableImageGallery,
-          // A null onAttachmentPressed makes Flyer hide the `+` button, so it
-          // only appears when the host wired up at least one attach callback.
-          onAttachmentPressed: _attachEnabled ? _showAttachMenu : null,
-          inputOptions: InputOptions(
-            textEditingController: _inputController,
-            // Keep the send button on screen at all times; _buildChatTheme
-            // grays its icon out while the field is empty or a reply is in
-            // flight.
-            sendButtonVisibilityMode: SendButtonVisibilityMode.always,
-            // Clear the field ourselves (in onSendPressed) only on an accepted
-            // send — so a send attempted while responding keeps the draft.
-            inputClearMode: InputClearMode.never,
-          ),
-          onSendPressed: (partialText) {
-            // Block sends while a reply is in flight. Returning early here
-            // also skips the clear below, so the user's draft is preserved.
-            if (widget.controller.isResponding) return;
-            widget.onSendMessage?.call(partialText.text);
-            widget.controller.sendText(partialText.text);
-            _inputController.clear();
-          },
-          onMessageTap: (_, message) {
-            final tapped = widget.controller.messageById(message.id);
-            if (tapped != null) widget.onMessageTap?.call(tapped);
-          },
-          onMessageVisibilityChanged: (message, visible) {
-            if (visible) widget.controller.markSeen(message.id);
-          },
-          textMessageBuilder:
-              (message, {required messageWidth, required showName}) {
-                return _TextMessageContent(
-                  message: message,
-                  maxWidth: messageWidth.toDouble(),
-                );
-              },
-          customMessageBuilder: (message, {required int messageWidth}) {
-            return _CustomMessageBubble(
-              message: widget.controller.messageById(message.id),
-              maxWidth: messageWidth.toDouble(),
-            );
-          },
-          typingIndicatorOptions: TypingIndicatorOptions(
-            typingUsers: widget.controller.isResponding
-                ? const <types.User>[aiAuthor]
-                : const <types.User>[],
-            customTypingIndicatorBuilder:
-                ({
-                  required context,
-                  required bubbleAlignment,
-                  required options,
-                  required indicatorOnScrollStatus,
-                }) => const _ThinkingIndicator(),
-          ),
-        );
 
-        final maxWidth = widget.maxContentWidth;
-        if (maxWidth == null) return chat;
-        // Center the conversation in a capped column on wide (desktop)
-        // viewports. The gutters take a dimmed surface tone so the column
-        // reads as an intentional, contained area rather than content
-        // floating in empty space. On narrow screens the column fills the
-        // width and the gutters are not visible.
-        return ColoredBox(
-          color: theme.colorScheme.surfaceContainer,
-          child: Center(
-            child: ConstrainedBox(
-              constraints: BoxConstraints(maxWidth: maxWidth),
-              child: chat,
-            ),
-          ),
-        );
-      },
+    // Built outside any ListenableBuilder: the message list reacts to the
+    // controller through `chatController`'s own stream, and only the composer
+    // depends on `isResponding` (it listens for itself). Keeping the builders
+    // stable here avoids rebuilding every visible message on each controller
+    // notification (e.g. a scroll-driven `markSeen`).
+    final Widget chat = Chat(
+      currentUserId: userAuthorId,
+      resolveUser: resolveCodifyChatUser,
+      chatController: widget.controller.chatController,
+      theme: ChatTheme.fromThemeData(theme),
+      onMessageSend: _handleSend,
+      onMessageTap: _handleMessageTap,
+      onAttachmentTap: _attachEnabled ? _showAttachMenu : null,
+      builders: Builders(
+        textMessageBuilder: _buildTextMessage,
+        imageMessageBuilder: _buildImageMessage,
+        fileMessageBuilder: _buildFileMessage,
+        customMessageBuilder: _buildCustomMessage,
+        emptyChatListBuilder: widget.emptyState == null
+            ? null
+            : _buildEmptyState,
+        composerBuilder: _buildComposer,
+      ),
+    );
+
+    final maxWidth = widget.maxContentWidth;
+    if (maxWidth == null) return chat;
+    // Center the conversation in a capped column on wide (desktop) viewports,
+    // with dimmed gutters so the column reads as a contained area. On narrow
+    // screens the column fills the width.
+    return ColoredBox(
+      color: theme.colorScheme.surfaceContainer,
+      child: Center(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: maxWidth),
+          child: chat,
+        ),
+      ),
     );
   }
+}
 
-  /// Derives a Flyer [ChatTheme] from the ambient Material 3 [ThemeData] so
-  /// the chat matches the surrounding CodifyIQ app.
-  ChatTheme _buildChatTheme(ThemeData theme) {
-    final colorScheme = theme.colorScheme;
-    final bodyStyle = theme.textTheme.bodyLarge ?? const TextStyle();
-    return DefaultChatTheme(
-      backgroundColor: colorScheme.surface,
-      primaryColor: colorScheme.primary,
-      secondaryColor: colorScheme.surfaceContainerHighest,
-      sentMessageBodyTextStyle: bodyStyle.copyWith(
-        color: colorScheme.onPrimary,
-      ),
-      receivedMessageBodyTextStyle: bodyStyle.copyWith(
-        color: colorScheme.onSurface,
-      ),
-      emptyChatPlaceholderTextStyle: bodyStyle.copyWith(
-        color: colorScheme.onSurfaceVariant,
-      ),
-      dateDividerTextStyle: (theme.textTheme.labelSmall ?? const TextStyle())
-          .copyWith(color: colorScheme.onSurfaceVariant),
-      inputBackgroundColor: colorScheme.surfaceContainerHighest,
-      inputSurfaceTintColor: colorScheme.surfaceTint,
-      inputTextColor: colorScheme.onSurface,
-      inputTextCursorColor: colorScheme.primary,
-      inputContainerDecoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHighest,
-      ),
-      receivedMessageDocumentIconColor: colorScheme.primary,
-      sentMessageDocumentIconColor: colorScheme.onPrimary,
-      sendButtonIcon: _SendButtonIcon(
-        controller: _inputController,
-        isResponding: widget.controller.isResponding,
-      ),
-      // The key rides on the icon so _showAttachMenu can anchor the menu to
-      // the `+` button's on-screen position.
-      attachmentButtonIcon: KeyedSubtree(
-        key: _attachButtonKey,
-        child: Icon(Icons.add, color: colorScheme.onSurfaceVariant),
-      ),
+/// The chat composer, isolated so it can rebuild on `isResponding` changes
+/// without rebuilding the message list.
+class _ChatComposer extends StatelessWidget {
+  const _ChatComposer({
+    required this.controller,
+    required this.textController,
+    required this.attachButtonKey,
+    required this.hintText,
+  });
+
+  final AiChatController controller;
+  final TextEditingController textController;
+  final Key attachButtonKey;
+  final String hintText;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (context, _) {
+        final isResponding = controller.isResponding;
+        return Composer(
+          textEditingController: textController,
+          hintText: hintText,
+          attachmentIcon: KeyedSubtree(
+            key: attachButtonKey,
+            child: const Icon(Icons.add),
+          ),
+          attachmentIconColor: colorScheme.onSurfaceVariant,
+          sendIcon: const Icon(Icons.send_rounded),
+          sendIconColor: colorScheme.primary,
+          emptyFieldSendIconColor: colorScheme.onSurface.withValues(
+            alpha: 0.38,
+          ),
+          // Grayed + non-tappable while the field is empty (native) or a
+          // reply is in flight.
+          sendButtonVisibilityMode: SendButtonVisibilityMode.disabled,
+          sendButtonDisabled: isResponding,
+          // The field is cleared by AiChatScreen only on an accepted send, so
+          // a send attempted while responding keeps the draft.
+          inputClearMode: InputClearMode.never,
+          keyboardType: TextInputType.multiline,
+          sendOnEnter: true,
+          topWidget: isResponding ? const _ThinkingIndicator() : null,
+        );
+      },
     );
   }
 }
@@ -354,128 +391,65 @@ class _AttachMenuItem extends StatelessWidget {
   }
 }
 
-/// Renders a text message inside Flyer's bubble.
-///
-/// AI replies are rendered as Markdown — AI backends typically return Markdown
-/// — while user messages stay plain text.
-class _TextMessageContent extends StatelessWidget {
-  const _TextMessageContent({required this.message, required this.maxWidth});
-
-  final types.TextMessage message;
-  final double maxWidth;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final isFromAi = message.author.id == aiAuthor.id;
-    final bodyStyle = (theme.textTheme.bodyLarge ?? const TextStyle()).copyWith(
-      color: isFromAi
-          ? theme.colorScheme.onSurface
-          : theme.colorScheme.onPrimary,
-    );
-    return ConstrainedBox(
-      constraints: BoxConstraints(maxWidth: maxWidth),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-        child: isFromAi
-            ? GptMarkdown(message.text, style: bodyStyle)
-            : Text(message.text, style: bodyStyle),
-      ),
-    );
-  }
-}
-
-/// Renders the placeholder / error bubbles for non-text messages.
-///
-/// The content sits inside Flyer's received-message bubble (painted with
-/// [ChatTheme.secondaryColor]); the error variant paints its own background
-/// to override that color.
+/// Renders the placeholder / error bubbles for the [CustomMessage]s produced
+/// by source-less image/pdf messages and error messages.
 class _CustomMessageBubble extends StatelessWidget {
-  const _CustomMessageBubble({required this.message, required this.maxWidth});
+  const _CustomMessageBubble({required this.message});
 
   final CodifyChatMessage? message;
-  final double maxWidth;
 
   @override
   Widget build(BuildContext context) {
     final message = this.message;
     if (message == null) return const SizedBox.shrink();
 
+    final colorScheme = Theme.of(context).colorScheme;
+    final isError = message.kind == CodifyChatMessageKind.error;
+
+    final String text;
     switch (message.kind) {
       case CodifyChatMessageKind.pdf:
-        return _PlaceholderBubble(
-          maxWidth: maxWidth,
-          text: '📄 PDF message (no file attached).',
-        );
+        text = '📄 PDF message (no file attached).';
       case CodifyChatMessageKind.image:
-        return _PlaceholderBubble(
-          maxWidth: maxWidth,
-          text: '🖼️ Image message (no file attached).',
-        );
+        text = '🖼️ Image message (no file attached).';
       case CodifyChatMessageKind.error:
-        return _ErrorBubble(maxWidth: maxWidth, text: message.text);
+        text = message.text;
       case CodifyChatMessageKind.text:
         // Text messages never reach the custom builder.
         return const SizedBox.shrink();
     }
-  }
-}
 
-/// A neutral bubble used for not-yet-supported PDF/image responses.
-class _PlaceholderBubble extends StatelessWidget {
-  const _PlaceholderBubble({required this.text, required this.maxWidth});
-
-  final String text;
-  final double maxWidth;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return ConstrainedBox(
-      constraints: BoxConstraints(maxWidth: maxWidth),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-        child: Text(
-          text,
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// A bubble that surfaces a failed chat turn in the theme's error colors.
-class _ErrorBubble extends StatelessWidget {
-  const _ErrorBubble({required this.text, required this.maxWidth});
-
-  final String text;
-  final double maxWidth;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return ConstrainedBox(
-      constraints: BoxConstraints(maxWidth: maxWidth),
+    return Align(
+      alignment: Alignment.centerLeft,
       child: Container(
-        color: theme.colorScheme.errorContainer,
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        margin: const EdgeInsets.fromLTRB(16, 4, 16, 4),
+        constraints: const BoxConstraints(maxWidth: 320),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: isError
+              ? colorScheme.errorContainer
+              : colorScheme.surfaceContainerHigh,
+          borderRadius: BorderRadius.circular(12),
+        ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Icon(
-              Icons.error_outline,
-              size: 20,
-              color: theme.colorScheme.onErrorContainer,
-            ),
-            const SizedBox(width: 8),
+            if (isError) ...[
+              Icon(
+                Icons.error_outline,
+                size: 20,
+                color: colorScheme.onErrorContainer,
+              ),
+              const SizedBox(width: 8),
+            ],
             Flexible(
               child: Text(
                 text,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: theme.colorScheme.onErrorContainer,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: isError
+                      ? colorScheme.onErrorContainer
+                      : colorScheme.onSurfaceVariant,
                 ),
               ),
             ),
@@ -486,60 +460,19 @@ class _ErrorBubble extends StatelessWidget {
   }
 }
 
-/// The loading indicator shown in Flyer's typing-indicator slot while the
-/// backend request is in flight. Reuses the package's [AiProgressIndicator].
+/// The loading indicator shown above the composer while a backend request is
+/// in flight. Reuses the package's [AiProgressIndicator].
 class _ThinkingIndicator extends StatelessWidget {
   const _ThinkingIndicator();
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: Container(
-        margin: const EdgeInsets.fromLTRB(24, 8, 24, 16),
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceContainerHighest,
-          borderRadius: BorderRadius.circular(20),
-        ),
-        child: AiProgressIndicator(
-          text: 'Thinking…',
-          textStyle: theme.textTheme.bodyMedium,
-        ),
+    return const Padding(
+      padding: EdgeInsets.fromLTRB(16, 8, 16, 0),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: AiProgressIndicator(text: 'Thinking…'),
       ),
-    );
-  }
-}
-
-/// The send-button icon, tinted to reflect whether a send is currently
-/// possible.
-///
-/// Flyer's `Input` always renders the send button (see
-/// [SendButtonVisibilityMode.always]); this widget listens to the input's
-/// [TextEditingController] and grays the icon out while the field is empty or
-/// a reply is in flight ([isResponding]), restoring the primary color only
-/// when the user has typed something and no request is pending.
-class _SendButtonIcon extends StatelessWidget {
-  const _SendButtonIcon({required this.controller, required this.isResponding});
-
-  final TextEditingController controller;
-  final bool isResponding;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    return ListenableBuilder(
-      listenable: controller,
-      builder: (context, _) {
-        final canSend = !isResponding && controller.text.trim().isNotEmpty;
-        return Icon(
-          Icons.send_rounded,
-          color: canSend
-              ? colorScheme.primary
-              : colorScheme.onSurface.withValues(alpha: 0.38),
-        );
-      },
     );
   }
 }

--- a/codifyiq_core_components/lib/widgets/ai_chat/codify_chat_message.dart
+++ b/codifyiq_core_components/lib/widgets/ai_chat/codify_chat_message.dart
@@ -179,7 +179,8 @@ class CodifyChatMessage {
   final Uri? sourceUri;
 
   /// Size of the attached file in bytes, shown as the subtitle on pdf/file
-  /// messages. `0` when the size is unknown.
+  /// messages. `0` when the size is unknown — the size line is then hidden
+  /// rather than rendered as "0 B".
   final int fileSizeBytes;
 
   /// Whether the message has been seen by the user.
@@ -215,4 +216,30 @@ class CodifyChatMessage {
       fileSizeBytes: fileSizeBytes ?? this.fileSizeBytes,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CodifyChatMessage &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          sender == other.sender &&
+          kind == other.kind &&
+          text == other.text &&
+          createdAt == other.createdAt &&
+          seenAt == other.seenAt &&
+          sourceUri == other.sourceUri &&
+          fileSizeBytes == other.fileSizeBytes;
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    sender,
+    kind,
+    text,
+    createdAt,
+    seenAt,
+    sourceUri,
+    fileSizeBytes,
+  );
 }

--- a/codifyiq_core_components/lib/widgets/ai_chat/codify_chat_message.dart
+++ b/codifyiq_core_components/lib/widgets/ai_chat/codify_chat_message.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/foundation.dart';
+
+/// Identifies who authored a [CodifyChatMessage].
+enum CodifyChatSender {
+  /// A message typed by the local user.
+  user,
+
+  /// A message produced by the AI backend.
+  ai,
+}
+
+/// The kind of content carried by a [CodifyChatMessage].
+///
+/// MVP renders [text] and [error] fully; [image] and [pdf] are accepted by the
+/// model and UI but render only as placeholder bubbles until dedicated viewers
+/// are integrated (reached via `AiChatScreen.onMessageTap`).
+enum CodifyChatMessageKind {
+  /// Plain text content.
+  text,
+
+  /// An image response — placeholder only in the MVP.
+  image,
+
+  /// A PDF response — placeholder only in the MVP.
+  pdf,
+
+  /// An error notice rendered as a distinct bubble.
+  error,
+}
+
+// Monotonic counter guaranteeing uniqueness when several messages are created
+// within the same microsecond.
+int _messageSequence = 0;
+
+String _generateMessageId() {
+  _messageSequence += 1;
+  return 'codify-chat-${DateTime.now().microsecondsSinceEpoch}-$_messageSequence';
+}
+
+/// A CodifyIQ chat message — the design-system wrapper model that
+/// `flyer_chat_mapper.dart` maps to and from Flyer Chat's message types.
+///
+/// Messages are immutable; produce modified copies with [copyWith]. Construct
+/// them with the named factories ([CodifyChatMessage.user],
+/// [CodifyChatMessage.ai], [CodifyChatMessage.pdf], [CodifyChatMessage.image],
+/// [CodifyChatMessage.error]) which assign a unique [id] and default the
+/// timestamp for you.
+@immutable
+class CodifyChatMessage {
+  /// Creates a [CodifyChatMessage] with every field supplied explicitly.
+  ///
+  /// Prefer the named factories for the common cases.
+  const CodifyChatMessage({
+    required this.id,
+    required this.sender,
+    required this.kind,
+    required this.text,
+    required this.createdAt,
+    this.seenAt,
+    this.sourceUri,
+    this.fileSizeBytes = 0,
+  });
+
+  /// Creates a text message authored by the local user.
+  factory CodifyChatMessage.user({
+    required String text,
+    String? id,
+    DateTime? createdAt,
+    DateTime? seenAt,
+  }) => CodifyChatMessage(
+    id: id ?? _generateMessageId(),
+    sender: CodifyChatSender.user,
+    kind: CodifyChatMessageKind.text,
+    text: text,
+    createdAt: createdAt ?? DateTime.now(),
+    seenAt: seenAt,
+  );
+
+  /// Creates a text message authored by the AI.
+  factory CodifyChatMessage.ai({
+    required String text,
+    String? id,
+    DateTime? createdAt,
+    DateTime? seenAt,
+  }) => CodifyChatMessage(
+    id: id ?? _generateMessageId(),
+    sender: CodifyChatSender.ai,
+    kind: CodifyChatMessageKind.text,
+    text: text,
+    createdAt: createdAt ?? DateTime.now(),
+    seenAt: seenAt,
+  );
+
+  /// Creates a PDF message.
+  ///
+  /// When [sourceUri] is set the message renders as a Flyer Chat file row
+  /// (document icon, [text] as the file name, and [fileSizeBytes] formatted as
+  /// the subtitle); tapping it surfaces through `AiChatScreen.onMessageTap`,
+  /// where the host opens its PDF viewer. With no [sourceUri] it falls back to
+  /// a placeholder bubble.
+  factory CodifyChatMessage.pdf({
+    String text = '',
+    Uri? sourceUri,
+    int fileSizeBytes = 0,
+    CodifyChatSender sender = CodifyChatSender.ai,
+    String? id,
+    DateTime? createdAt,
+    DateTime? seenAt,
+  }) => CodifyChatMessage(
+    id: id ?? _generateMessageId(),
+    sender: sender,
+    kind: CodifyChatMessageKind.pdf,
+    text: text,
+    createdAt: createdAt ?? DateTime.now(),
+    seenAt: seenAt,
+    sourceUri: sourceUri,
+    fileSizeBytes: fileSizeBytes,
+  );
+
+  /// Creates an image message.
+  ///
+  /// Renders as a placeholder bubble in the MVP. [text] is an optional caption
+  /// and [sourceUri] is reserved for the future image viewer.
+  factory CodifyChatMessage.image({
+    String text = '',
+    Uri? sourceUri,
+    CodifyChatSender sender = CodifyChatSender.ai,
+    String? id,
+    DateTime? createdAt,
+    DateTime? seenAt,
+  }) => CodifyChatMessage(
+    id: id ?? _generateMessageId(),
+    sender: sender,
+    kind: CodifyChatMessageKind.image,
+    text: text,
+    createdAt: createdAt ?? DateTime.now(),
+    seenAt: seenAt,
+    sourceUri: sourceUri,
+  );
+
+  /// Creates an error message, rendered as a distinct error bubble.
+  factory CodifyChatMessage.error({
+    required String text,
+    String? id,
+    DateTime? createdAt,
+  }) => CodifyChatMessage(
+    id: id ?? _generateMessageId(),
+    sender: CodifyChatSender.ai,
+    kind: CodifyChatMessageKind.error,
+    text: text,
+    createdAt: createdAt ?? DateTime.now(),
+  );
+
+  /// Stable identifier, unique within a conversation.
+  final String id;
+
+  /// Who authored the message.
+  final CodifyChatSender sender;
+
+  /// The kind of content carried by the message.
+  final CodifyChatMessageKind kind;
+
+  /// The body for [CodifyChatMessageKind.text] / [CodifyChatMessageKind.error],
+  /// or an optional caption/label for [CodifyChatMessageKind.image] /
+  /// [CodifyChatMessageKind.pdf].
+  final String text;
+
+  /// When the message was created.
+  final DateTime createdAt;
+
+  /// When the message first became visible to the user, or `null` if it has
+  /// not been seen yet. Set automatically by `AiChatController.markSeen`.
+  final DateTime? seenAt;
+
+  /// The network or local source of the image/pdf content.
+  ///
+  /// Image messages render inline when this is set; pdf messages render as a
+  /// tappable Flyer Chat file row. `null` falls back to a placeholder bubble.
+  final Uri? sourceUri;
+
+  /// Size of the attached file in bytes, shown as the subtitle on pdf/file
+  /// messages. `0` when the size is unknown.
+  final int fileSizeBytes;
+
+  /// Whether the message has been seen by the user.
+  bool get isSeen => seenAt != null;
+
+  /// Whether the message was authored by the local user.
+  bool get isFromUser => sender == CodifyChatSender.user;
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass [clearSeenAt] or [clearSourceUri] to explicitly reset those nullable
+  /// fields back to `null`.
+  CodifyChatMessage copyWith({
+    String? id,
+    CodifyChatSender? sender,
+    CodifyChatMessageKind? kind,
+    String? text,
+    DateTime? createdAt,
+    DateTime? seenAt,
+    Uri? sourceUri,
+    int? fileSizeBytes,
+    bool clearSeenAt = false,
+    bool clearSourceUri = false,
+  }) {
+    return CodifyChatMessage(
+      id: id ?? this.id,
+      sender: sender ?? this.sender,
+      kind: kind ?? this.kind,
+      text: text ?? this.text,
+      createdAt: createdAt ?? this.createdAt,
+      seenAt: clearSeenAt ? null : (seenAt ?? this.seenAt),
+      sourceUri: clearSourceUri ? null : (sourceUri ?? this.sourceUri),
+      fileSizeBytes: fileSizeBytes ?? this.fileSizeBytes,
+    );
+  }
+}

--- a/codifyiq_core_components/lib/widgets/ai_chat/flyer_chat_mapper.dart
+++ b/codifyiq_core_components/lib/widgets/ai_chat/flyer_chat_mapper.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+
+import 'codify_chat_message.dart';
+
+/// Maps [CodifyChatMessage]s to Flyer Chat's `flutter_chat_types` model.
+///
+/// This is the only file in the `ai_chat` component that depends on
+/// `flutter_chat_types`, keeping the wrapper model and the Flyer types
+/// decoupled. It is an internal implementation detail and is not exported
+/// from the package.
+
+/// Stable Flyer author for messages sent by the local user.
+const types.User userAuthor = types.User(
+  id: 'codify-chat-user',
+  firstName: 'You',
+);
+
+/// Stable Flyer author for messages produced by the AI.
+const types.User aiAuthor = types.User(
+  id: 'codify-chat-ai',
+  firstName: 'Assistant',
+);
+
+types.User _authorFor(CodifyChatSender sender) =>
+    sender == CodifyChatSender.user ? userAuthor : aiAuthor;
+
+/// Converts a single [CodifyChatMessage] to a Flyer [types.Message].
+///
+/// - Text messages become [types.TextMessage].
+/// - Image messages with a [CodifyChatMessage.sourceUri] become
+///   [types.ImageMessage] so Flyer renders the picture inline (and provides
+///   tap-to-zoom). Images render from the network or the local file system —
+///   no heavy native package is involved.
+/// - PDF messages with a [CodifyChatMessage.sourceUri] become
+///   [types.FileMessage] so Flyer renders a tappable file row; the tap is
+///   forwarded through `AiChatScreen.onMessageTap` for the host to open its
+///   PDF viewer. No PDF rendering library is pulled into the chat widget.
+/// - Error messages and source-less image/pdf messages become
+///   [types.CustomMessage] so `AiChatScreen` renders them through its
+///   `customMessageBuilder` (placeholder / error bubbles).
+types.Message toFlyerMessage(CodifyChatMessage message) {
+  final author = _authorFor(message.sender);
+  final createdAt = message.createdAt.millisecondsSinceEpoch;
+
+  switch (message.kind) {
+    case CodifyChatMessageKind.text:
+      return types.TextMessage(
+        author: author,
+        id: message.id,
+        text: message.text,
+        createdAt: createdAt,
+        showStatus: message.isFromUser,
+        status: message.isSeen ? types.Status.seen : types.Status.sent,
+      );
+    case CodifyChatMessageKind.image:
+      final source = message.sourceUri;
+      if (source != null) {
+        return types.ImageMessage(
+          author: author,
+          id: message.id,
+          createdAt: createdAt,
+          uri: source.toString(),
+          // Flyer shows [name] only in its small file-style fallback layout;
+          // [size] is unknown for a remote image and is left at 0.
+          name: message.text.isEmpty ? 'image' : message.text,
+          size: 0,
+          showStatus: message.isFromUser,
+          status: message.isSeen ? types.Status.seen : types.Status.sent,
+        );
+      }
+      // No source yet — fall back to a placeholder bubble.
+      return _placeholderMessage(message, author, createdAt);
+    case CodifyChatMessageKind.pdf:
+      final source = message.sourceUri;
+      if (source != null) {
+        return types.FileMessage(
+          author: author,
+          id: message.id,
+          createdAt: createdAt,
+          uri: source.toString(),
+          name: message.text.isEmpty ? 'document.pdf' : message.text,
+          size: message.fileSizeBytes,
+          mimeType: 'application/pdf',
+          showStatus: message.isFromUser,
+          status: message.isSeen ? types.Status.seen : types.Status.sent,
+        );
+      }
+      // No source yet — fall back to a placeholder bubble.
+      return _placeholderMessage(message, author, createdAt);
+    case CodifyChatMessageKind.error:
+      return _placeholderMessage(message, author, createdAt);
+  }
+}
+
+/// Builds the [types.CustomMessage] that drives a placeholder / error bubble.
+///
+/// No metadata is attached: `AiChatScreen` resolves the bubble's content kind
+/// straight from the [AiChatController] by message id.
+types.CustomMessage _placeholderMessage(
+  CodifyChatMessage message,
+  types.User author,
+  int createdAt,
+) => types.CustomMessage(author: author, id: message.id, createdAt: createdAt);
+
+/// Converts a timeline (oldest first) into the newest-first list that Flyer
+/// Chat's `Chat` widget expects.
+List<types.Message> toFlyerMessages(List<CodifyChatMessage> messages) =>
+    <types.Message>[
+      for (final message in messages.reversed) toFlyerMessage(message),
+    ];

--- a/codifyiq_core_components/lib/widgets/ai_chat/flyer_chat_mapper.dart
+++ b/codifyiq_core_components/lib/widgets/ai_chat/flyer_chat_mapper.dart
@@ -1,110 +1,98 @@
-import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+import 'package:flutter_chat_core/flutter_chat_core.dart';
 
 import 'codify_chat_message.dart';
 
-/// Maps [CodifyChatMessage]s to Flyer Chat's `flutter_chat_types` model.
+/// Maps [CodifyChatMessage]s onto the Flyer Chat (`flutter_chat_core`)
+/// [Message] model.
 ///
 /// This is the only file in the `ai_chat` component that depends on
-/// `flutter_chat_types`, keeping the wrapper model and the Flyer types
-/// decoupled. It is an internal implementation detail and is not exported
-/// from the package.
+/// `flutter_chat_core`, keeping the CodifyIQ wrapper model decoupled from
+/// Flyer. It is an internal implementation detail and is not exported from the
+/// package.
 
-/// Stable Flyer author for messages sent by the local user.
-const types.User userAuthor = types.User(
-  id: 'codify-chat-user',
-  firstName: 'You',
-);
+/// Stable Flyer user id for messages sent by the local user.
+const String userAuthorId = 'codify-chat-user';
 
-/// Stable Flyer author for messages produced by the AI.
-const types.User aiAuthor = types.User(
-  id: 'codify-chat-ai',
-  firstName: 'Assistant',
-);
+/// Stable Flyer user id for messages produced by the AI.
+const String aiAuthorId = 'codify-chat-ai';
 
-types.User _authorFor(CodifyChatSender sender) =>
-    sender == CodifyChatSender.user ? userAuthor : aiAuthor;
+const Map<String, User> _users = <String, User>{
+  userAuthorId: User(id: userAuthorId, name: 'You'),
+  aiAuthorId: User(id: aiAuthorId, name: 'Assistant'),
+};
 
-/// Converts a single [CodifyChatMessage] to a Flyer [types.Message].
+/// Resolves the [User] for a Flyer message author id.
 ///
-/// - Text messages become [types.TextMessage].
-/// - Image messages with a [CodifyChatMessage.sourceUri] become
-///   [types.ImageMessage] so Flyer renders the picture inline (and provides
-///   tap-to-zoom). Images render from the network or the local file system —
-///   no heavy native package is involved.
-/// - PDF messages with a [CodifyChatMessage.sourceUri] become
-///   [types.FileMessage] so Flyer renders a tappable file row; the tap is
-///   forwarded through `AiChatScreen.onMessageTap` for the host to open its
-///   PDF viewer. No PDF rendering library is pulled into the chat widget.
-/// - Error messages and source-less image/pdf messages become
-///   [types.CustomMessage] so `AiChatScreen` renders them through its
-///   `customMessageBuilder` (placeholder / error bubbles).
-types.Message toFlyerMessage(CodifyChatMessage message) {
-  final author = _authorFor(message.sender);
-  final createdAt = message.createdAt.millisecondsSinceEpoch;
+/// Wired into `Chat.resolveUser`. Returns `null` for unknown ids.
+Future<User?> resolveCodifyChatUser(UserID id) async => _users[id];
+
+String _authorIdFor(CodifyChatSender sender) =>
+    sender == CodifyChatSender.user ? userAuthorId : aiAuthorId;
+
+/// Converts a [CodifyChatMessage] to a Flyer [Message].
+///
+/// - Text → [TextMessage] (rendered with Markdown by `FlyerChatTextMessage`).
+/// - Image with a [CodifyChatMessage.sourceUri] → [ImageMessage], rendered
+///   inline by `FlyerChatImageMessage`.
+/// - PDF with a [CodifyChatMessage.sourceUri] → [FileMessage], rendered as a
+///   tappable file row by `FlyerChatFileMessage`.
+/// - Error messages and source-less image/pdf messages → [CustomMessage], so
+///   `AiChatScreen` renders them through its custom builder (placeholder /
+///   error bubbles). No PDF/image rendering library is pulled in for those.
+Message toFlyerMessage(CodifyChatMessage message) {
+  final authorId = _authorIdFor(message.sender);
 
   switch (message.kind) {
     case CodifyChatMessageKind.text:
-      return types.TextMessage(
-        author: author,
+      return Message.text(
         id: message.id,
+        authorId: authorId,
         text: message.text,
-        createdAt: createdAt,
-        showStatus: message.isFromUser,
-        status: message.isSeen ? types.Status.seen : types.Status.sent,
+        createdAt: message.createdAt,
+        seenAt: message.seenAt,
       );
     case CodifyChatMessageKind.image:
       final source = message.sourceUri;
       if (source != null) {
-        return types.ImageMessage(
-          author: author,
+        return Message.image(
           id: message.id,
-          createdAt: createdAt,
-          uri: source.toString(),
-          // Flyer shows [name] only in its small file-style fallback layout;
-          // [size] is unknown for a remote image and is left at 0.
-          name: message.text.isEmpty ? 'image' : message.text,
-          size: 0,
-          showStatus: message.isFromUser,
-          status: message.isSeen ? types.Status.seen : types.Status.sent,
+          authorId: authorId,
+          source: source.toString(),
+          text: message.text.isEmpty ? null : message.text,
+          createdAt: message.createdAt,
+          seenAt: message.seenAt,
         );
       }
-      // No source yet — fall back to a placeholder bubble.
-      return _placeholderMessage(message, author, createdAt);
+      return _customMessage(message, authorId);
     case CodifyChatMessageKind.pdf:
       final source = message.sourceUri;
       if (source != null) {
-        return types.FileMessage(
-          author: author,
+        return Message.file(
           id: message.id,
-          createdAt: createdAt,
-          uri: source.toString(),
+          authorId: authorId,
+          source: source.toString(),
           name: message.text.isEmpty ? 'document.pdf' : message.text,
-          size: message.fileSizeBytes,
+          // 0 means "unknown" — passing null hides the size line on the
+          // Flyer file row rather than rendering a meaningless "0 B".
+          size: message.fileSizeBytes == 0 ? null : message.fileSizeBytes,
           mimeType: 'application/pdf',
-          showStatus: message.isFromUser,
-          status: message.isSeen ? types.Status.seen : types.Status.sent,
+          createdAt: message.createdAt,
+          seenAt: message.seenAt,
         );
       }
-      // No source yet — fall back to a placeholder bubble.
-      return _placeholderMessage(message, author, createdAt);
+      return _customMessage(message, authorId);
     case CodifyChatMessageKind.error:
-      return _placeholderMessage(message, author, createdAt);
+      return _customMessage(message, authorId);
   }
 }
 
-/// Builds the [types.CustomMessage] that drives a placeholder / error bubble.
+/// Builds the [CustomMessage] that drives a placeholder / error bubble.
 ///
 /// No metadata is attached: `AiChatScreen` resolves the bubble's content kind
 /// straight from the [AiChatController] by message id.
-types.CustomMessage _placeholderMessage(
-  CodifyChatMessage message,
-  types.User author,
-  int createdAt,
-) => types.CustomMessage(author: author, id: message.id, createdAt: createdAt);
-
-/// Converts a timeline (oldest first) into the newest-first list that Flyer
-/// Chat's `Chat` widget expects.
-List<types.Message> toFlyerMessages(List<CodifyChatMessage> messages) =>
-    <types.Message>[
-      for (final message in messages.reversed) toFlyerMessage(message),
-    ];
+Message _customMessage(CodifyChatMessage message, String authorId) =>
+    Message.custom(
+      id: message.id,
+      authorId: authorId,
+      createdAt: message.createdAt,
+    );

--- a/codifyiq_core_components/pubspec.yaml
+++ b/codifyiq_core_components/pubspec.yaml
@@ -25,10 +25,12 @@ dependencies:
   adaptive_theme: ^3.7.0
   shimmer: ^3.0.0
   pdfrx: ^2.3.3
-  # Pinned to the flutter_chat_ui v1 line: v2 dropped flutter_chat_types,
-  # which the AI chat message mapping depends on.
-  flutter_chat_ui: ^1.6.15
-  flutter_chat_types: ^3.6.2
+  flutter_chat_ui: ^2.0.0
+  flutter_chat_core: ^2.0.0
+  flyer_chat_text_message: ^2.0.0
+  flyer_chat_image_message: ^2.0.0
+  flyer_chat_file_message: ^2.0.0
+  visibility_detector: ^0.4.0+2
   photo_view: ^0.15.0
 
 dev_dependencies:

--- a/codifyiq_core_components/pubspec.yaml
+++ b/codifyiq_core_components/pubspec.yaml
@@ -25,6 +25,10 @@ dependencies:
   adaptive_theme: ^3.7.0
   shimmer: ^3.0.0
   pdfrx: ^2.3.3
+  # Pinned to the flutter_chat_ui v1 line: v2 dropped flutter_chat_types,
+  # which the AI chat message mapping depends on.
+  flutter_chat_ui: ^1.6.15
+  flutter_chat_types: ^3.6.2
 
 dev_dependencies:
   flutter_test:

--- a/codifyiq_core_components/test/ai_chat_controller_test.dart
+++ b/codifyiq_core_components/test/ai_chat_controller_test.dart
@@ -85,6 +85,52 @@ void main() {
       await expectLater(pending, completes);
     });
 
+    test('clear() during a response resets isResponding and drops the late '
+        'reply', () async {
+      final completer = Completer<CodifyChatMessage>();
+      final controller = AiChatController(
+        responder: (prompt) => completer.future,
+      );
+
+      final pending = controller.sendText('hello');
+      expect(controller.isResponding, isTrue);
+
+      controller.clear();
+      expect(controller.isResponding, isFalse);
+      expect(controller.messages, isEmpty);
+
+      completer.complete(CodifyChatMessage.ai(text: 'late reply'));
+      await pending;
+
+      // The late reply is dropped, not appended to the cleared timeline.
+      expect(controller.messages, isEmpty);
+      expect(controller.isResponding, isFalse);
+    });
+
+    test('a send started after clear() is unaffected by the dropped '
+        'reply', () async {
+      final first = Completer<CodifyChatMessage>();
+      final second = Completer<CodifyChatMessage>();
+      var call = 0;
+      final controller = AiChatController(
+        responder: (prompt) => (call++ == 0) ? first.future : second.future,
+      );
+
+      final firstSend = controller.sendText('first');
+      controller.clear();
+
+      final secondSend = controller.sendText('second');
+      // The stale reply to the cleared send lands — it must be dropped.
+      first.complete(CodifyChatMessage.ai(text: 'stale'));
+      await firstSend;
+      expect(controller.messages.map((m) => m.text), ['second']);
+
+      second.complete(CodifyChatMessage.ai(text: 'fresh'));
+      await secondSend;
+      expect(controller.messages.map((m) => m.text), ['second', 'fresh']);
+      expect(controller.isResponding, isFalse);
+    });
+
     test('sendText is ignored while a request is in flight', () async {
       final completer = Completer<CodifyChatMessage>();
       final controller = AiChatController(
@@ -137,6 +183,42 @@ void main() {
 
       expect(controller.messages, hasLength(1));
       expect(controller.messages.single.kind, CodifyChatMessageKind.pdf);
+    });
+
+    test('chatController mirror stays in sync with the timeline', () async {
+      final controller = AiChatController(
+        responder: (prompt) async => CodifyChatMessage.ai(text: 'reply'),
+        initialMessages: [CodifyChatMessage.ai(text: 'greeting', id: 'g1')],
+      );
+
+      // The seed is mirrored into the Flyer controller.
+      expect(controller.chatController.messages.map((m) => m.id), ['g1']);
+
+      await controller.sendText('hello');
+
+      // The user message and the reply are mirrored, in the same order.
+      expect(
+        controller.chatController.messages.map((m) => m.id),
+        controller.messages.map((m) => m.id),
+      );
+
+      controller.clear();
+      expect(controller.chatController.messages, isEmpty);
+    });
+
+    test('markSeen propagates seenAt to the chatController mirror', () {
+      final seenAt = DateTime(2026, 5, 19, 12);
+      final controller = AiChatController(
+        responder: (prompt) async => CodifyChatMessage.ai(text: 'reply'),
+        initialMessages: [CodifyChatMessage.ai(text: 'hi', id: 'm1')],
+        clock: () => seenAt,
+      );
+
+      expect(controller.chatController.messages.single.seenAt, isNull);
+
+      controller.markSeen('m1');
+
+      expect(controller.chatController.messages.single.seenAt, seenAt);
     });
   });
 }

--- a/codifyiq_core_components/test/ai_chat_controller_test.dart
+++ b/codifyiq_core_components/test/ai_chat_controller_test.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:codifyiq_core_components/codifyiq_core_components.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AiChatController', () {
+    test('sendText appends the user message then the AI reply', () async {
+      final controller = AiChatController(
+        responder: (prompt) async => CodifyChatMessage.ai(text: 'reply'),
+      );
+
+      await controller.sendText('hello');
+
+      expect(controller.messages, hasLength(2));
+      expect(controller.messages[0].sender, CodifyChatSender.user);
+      expect(controller.messages[0].text, 'hello');
+      expect(controller.messages[1].sender, CodifyChatSender.ai);
+      expect(controller.messages[1].text, 'reply');
+    });
+
+    test('sendText trims whitespace and ignores blank input', () async {
+      final controller = AiChatController(
+        responder: (prompt) async => CodifyChatMessage.ai(text: 'reply'),
+      );
+
+      await controller.sendText('   ');
+      expect(controller.messages, isEmpty);
+
+      await controller.sendText('  spaced  ');
+      expect(controller.messages.first.text, 'spaced');
+    });
+
+    test('isResponding is true while awaiting and false afterwards', () async {
+      final completer = Completer<CodifyChatMessage>();
+      final controller = AiChatController(
+        responder: (prompt) => completer.future,
+      );
+
+      expect(controller.isResponding, isFalse);
+
+      final pending = controller.sendText('hello');
+      expect(controller.isResponding, isTrue);
+
+      completer.complete(CodifyChatMessage.ai(text: 'reply'));
+      await pending;
+      expect(controller.isResponding, isFalse);
+    });
+
+    test('a throwing responder appends an error bubble and reports the '
+        'underlying error', () async {
+      final reported = <Object>[];
+      final previousOnError = FlutterError.onError;
+      FlutterError.onError = (details) => reported.add(details.exception);
+      addTearDown(() => FlutterError.onError = previousOnError);
+
+      final controller = AiChatController(
+        responder: (prompt) async => throw Exception('backend down'),
+      );
+
+      await controller.sendText('hello');
+
+      expect(controller.messages, hasLength(2));
+      final last = controller.messages.last;
+      expect(last.kind, CodifyChatMessageKind.error);
+      expect(last.sender, CodifyChatSender.ai);
+      // The responder's exception is surfaced, not silently swallowed.
+      expect(reported, hasLength(1));
+      expect(reported.single, isA<Exception>());
+    });
+
+    test('disposing mid-response does not notify after dispose', () async {
+      final completer = Completer<CodifyChatMessage>();
+      final controller = AiChatController(
+        responder: (prompt) => completer.future,
+      );
+
+      final pending = controller.sendText('hello');
+      controller.dispose(); // user navigates away while the reply is in flight
+      completer.complete(CodifyChatMessage.ai(text: 'reply'));
+
+      // sendText must bail instead of calling notifyListeners() on a disposed
+      // controller, which would throw a "used after dispose" assertion.
+      await expectLater(pending, completes);
+    });
+
+    test('sendText is ignored while a request is in flight', () async {
+      final completer = Completer<CodifyChatMessage>();
+      final controller = AiChatController(
+        responder: (prompt) => completer.future,
+      );
+
+      final pending = controller.sendText('first');
+      await controller.sendText('second');
+
+      // Only the first user message is present; the second send was dropped.
+      expect(controller.messages.where((m) => m.isFromUser), hasLength(1));
+
+      completer.complete(CodifyChatMessage.ai(text: 'reply'));
+      await pending;
+    });
+
+    test('markSeen stamps seenAt once using the injected clock', () {
+      final seenTime = DateTime(2026, 5, 18, 9, 30);
+      final controller = AiChatController(
+        responder: (prompt) async => CodifyChatMessage.ai(text: 'reply'),
+        initialMessages: [CodifyChatMessage.ai(text: 'hi', id: 'm1')],
+        clock: () => seenTime,
+      );
+
+      expect(controller.messageById('m1')!.isSeen, isFalse);
+
+      controller.markSeen('m1');
+      expect(controller.messageById('m1')!.seenAt, seenTime);
+
+      // Idempotent: a second call does not move the timestamp.
+      controller.markSeen('m1');
+      expect(controller.messageById('m1')!.seenAt, seenTime);
+    });
+
+    test('markSeen is a no-op for an unknown id', () {
+      final controller = AiChatController(
+        responder: (prompt) async => CodifyChatMessage.ai(text: 'reply'),
+      );
+
+      controller.markSeen('does-not-exist');
+      expect(controller.messages, isEmpty);
+    });
+
+    test('addMessage appends directly without a backend round-trip', () {
+      final controller = AiChatController(
+        responder: (prompt) async => CodifyChatMessage.ai(text: 'reply'),
+      );
+
+      controller.addMessage(CodifyChatMessage.pdf(text: 'report.pdf'));
+
+      expect(controller.messages, hasLength(1));
+      expect(controller.messages.single.kind, CodifyChatMessageKind.pdf);
+    });
+  });
+}

--- a/codifyiq_core_components/test/codify_chat_message_test.dart
+++ b/codifyiq_core_components/test/codify_chat_message_test.dart
@@ -1,0 +1,49 @@
+import 'package:codifyiq_core_components/codifyiq_core_components.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CodifyChatMessage', () {
+    test('value equality and hashCode cover every field', () {
+      final createdAt = DateTime(2026, 5, 19, 10);
+      final a = CodifyChatMessage(
+        id: 'm1',
+        sender: CodifyChatSender.user,
+        kind: CodifyChatMessageKind.text,
+        text: 'hi',
+        createdAt: createdAt,
+      );
+      final b = CodifyChatMessage(
+        id: 'm1',
+        sender: CodifyChatSender.user,
+        kind: CodifyChatMessageKind.text,
+        text: 'hi',
+        createdAt: createdAt,
+      );
+
+      // Distinct instances with identical fields compare equal.
+      expect(identical(a, b), isFalse);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+
+      // Changing any individual field breaks equality.
+      expect(a, isNot(a.copyWith(text: 'changed')));
+      expect(a, isNot(a.copyWith(seenAt: DateTime(2026, 5, 20))));
+      expect(
+        a,
+        isNot(a.copyWith(sourceUri: Uri.parse('https://example.com/x'))),
+      );
+      expect(a, isNot(a.copyWith(fileSizeBytes: 99)));
+      expect(a, isNot(a.copyWith(sender: CodifyChatSender.ai)));
+      expect(a, isNot(a.copyWith(kind: CodifyChatMessageKind.error)));
+    });
+
+    test('copyWith with no overrides equals the source', () {
+      final original = CodifyChatMessage.ai(
+        text: 'hello',
+        id: 'm2',
+        createdAt: DateTime(2026, 5, 19),
+      );
+      expect(original.copyWith(), original);
+    });
+  });
+}

--- a/codifyiq_core_components/test/flyer_chat_mapper_test.dart
+++ b/codifyiq_core_components/test/flyer_chat_mapper_test.dart
@@ -1,6 +1,6 @@
 import 'package:codifyiq_core_components/codifyiq_core_components.dart';
 import 'package:codifyiq_core_components/widgets/ai_chat/flyer_chat_mapper.dart';
-import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+import 'package:flutter_chat_core/flutter_chat_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -8,8 +8,8 @@ void main() {
     test('text message maps to a Flyer TextMessage', () {
       final flyer = toFlyerMessage(CodifyChatMessage.ai(text: 'hello'));
 
-      expect(flyer, isA<types.TextMessage>());
-      expect((flyer as types.TextMessage).text, 'hello');
+      expect(flyer, isA<TextMessage>());
+      expect((flyer as TextMessage).text, 'hello');
     });
 
     test('image with a sourceUri maps to a Flyer ImageMessage', () {
@@ -20,16 +20,12 @@ void main() {
         ),
       );
 
-      expect(flyer, isA<types.ImageMessage>());
-      final image = flyer as types.ImageMessage;
-      expect(image.uri, 'https://example.com/photo.png');
-      expect(image.name, 'photo.png');
+      expect(flyer, isA<ImageMessage>());
+      expect((flyer as ImageMessage).source, 'https://example.com/photo.png');
     });
 
     test('image without a sourceUri falls back to a CustomMessage', () {
-      final flyer = toFlyerMessage(CodifyChatMessage.image());
-
-      expect(flyer, isA<types.CustomMessage>());
+      expect(toFlyerMessage(CodifyChatMessage.image()), isA<CustomMessage>());
     });
 
     test('pdf with a sourceUri maps to a Flyer FileMessage', () {
@@ -41,47 +37,66 @@ void main() {
         ),
       );
 
-      expect(flyer, isA<types.FileMessage>());
-      final file = flyer as types.FileMessage;
-      expect(file.uri, 'https://example.com/report.pdf');
+      expect(flyer, isA<FileMessage>());
+      final file = flyer as FileMessage;
+      expect(file.source, 'https://example.com/report.pdf');
       expect(file.name, 'report.pdf');
       expect(file.size, 2048);
       expect(file.mimeType, 'application/pdf');
     });
 
+    test('pdf with an unknown fileSizeBytes maps size to null', () {
+      final flyer = toFlyerMessage(
+        CodifyChatMessage.pdf(
+          text: 'report.pdf',
+          sourceUri: Uri.parse('https://example.com/report.pdf'),
+          // fileSizeBytes defaults to 0 == unknown.
+        ),
+      );
+
+      expect((flyer as FileMessage).size, isNull);
+    });
+
     test('pdf without a sourceUri falls back to a CustomMessage', () {
       expect(
         toFlyerMessage(CodifyChatMessage.pdf(text: 'report.pdf')),
-        isA<types.CustomMessage>(),
+        isA<CustomMessage>(),
       );
     });
 
     test('error messages map to a CustomMessage', () {
       expect(
         toFlyerMessage(CodifyChatMessage.error(text: 'failed')),
-        isA<types.CustomMessage>(),
+        isA<CustomMessage>(),
       );
     });
 
-    test('user and ai messages get distinct Flyer authors', () {
+    test('user and ai messages get distinct Flyer author ids', () {
       final user = toFlyerMessage(CodifyChatMessage.user(text: 'hi'));
       final ai = toFlyerMessage(CodifyChatMessage.ai(text: 'hello'));
 
-      expect(user.author.id, userAuthor.id);
-      expect(ai.author.id, aiAuthor.id);
+      expect(user.authorId, userAuthorId);
+      expect(ai.authorId, aiAuthorId);
+      expect(userAuthorId, isNot(aiAuthorId));
+    });
+
+    test('createdAt and seenAt are carried onto the Flyer message', () {
+      final created = DateTime(2026, 5, 19, 10);
+      final seen = DateTime(2026, 5, 19, 11);
+      final flyer = toFlyerMessage(
+        CodifyChatMessage.ai(text: 'hi', createdAt: created, seenAt: seen),
+      );
+
+      expect(flyer.createdAt, created);
+      expect(flyer.seenAt, seen);
     });
   });
 
-  group('toFlyerMessages', () {
-    test('reverses the timeline to the newest-first order Flyer expects', () {
-      final timeline = [
-        CodifyChatMessage.user(text: 'first', id: 'a'),
-        CodifyChatMessage.ai(text: 'second', id: 'b'),
-      ];
-
-      final flyer = toFlyerMessages(timeline);
-
-      expect(flyer.map((m) => m.id), ['b', 'a']);
+  group('resolveCodifyChatUser', () {
+    test('resolves the known author ids and null for anything else', () async {
+      expect((await resolveCodifyChatUser(userAuthorId))?.id, userAuthorId);
+      expect((await resolveCodifyChatUser(aiAuthorId))?.id, aiAuthorId);
+      expect(await resolveCodifyChatUser('someone-else'), isNull);
     });
   });
 }

--- a/codifyiq_core_components/test/flyer_chat_mapper_test.dart
+++ b/codifyiq_core_components/test/flyer_chat_mapper_test.dart
@@ -1,0 +1,87 @@
+import 'package:codifyiq_core_components/codifyiq_core_components.dart';
+import 'package:codifyiq_core_components/widgets/ai_chat/flyer_chat_mapper.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('toFlyerMessage', () {
+    test('text message maps to a Flyer TextMessage', () {
+      final flyer = toFlyerMessage(CodifyChatMessage.ai(text: 'hello'));
+
+      expect(flyer, isA<types.TextMessage>());
+      expect((flyer as types.TextMessage).text, 'hello');
+    });
+
+    test('image with a sourceUri maps to a Flyer ImageMessage', () {
+      final flyer = toFlyerMessage(
+        CodifyChatMessage.image(
+          text: 'photo.png',
+          sourceUri: Uri.parse('https://example.com/photo.png'),
+        ),
+      );
+
+      expect(flyer, isA<types.ImageMessage>());
+      final image = flyer as types.ImageMessage;
+      expect(image.uri, 'https://example.com/photo.png');
+      expect(image.name, 'photo.png');
+    });
+
+    test('image without a sourceUri falls back to a CustomMessage', () {
+      final flyer = toFlyerMessage(CodifyChatMessage.image());
+
+      expect(flyer, isA<types.CustomMessage>());
+    });
+
+    test('pdf with a sourceUri maps to a Flyer FileMessage', () {
+      final flyer = toFlyerMessage(
+        CodifyChatMessage.pdf(
+          text: 'report.pdf',
+          sourceUri: Uri.parse('https://example.com/report.pdf'),
+          fileSizeBytes: 2048,
+        ),
+      );
+
+      expect(flyer, isA<types.FileMessage>());
+      final file = flyer as types.FileMessage;
+      expect(file.uri, 'https://example.com/report.pdf');
+      expect(file.name, 'report.pdf');
+      expect(file.size, 2048);
+      expect(file.mimeType, 'application/pdf');
+    });
+
+    test('pdf without a sourceUri falls back to a CustomMessage', () {
+      expect(
+        toFlyerMessage(CodifyChatMessage.pdf(text: 'report.pdf')),
+        isA<types.CustomMessage>(),
+      );
+    });
+
+    test('error messages map to a CustomMessage', () {
+      expect(
+        toFlyerMessage(CodifyChatMessage.error(text: 'failed')),
+        isA<types.CustomMessage>(),
+      );
+    });
+
+    test('user and ai messages get distinct Flyer authors', () {
+      final user = toFlyerMessage(CodifyChatMessage.user(text: 'hi'));
+      final ai = toFlyerMessage(CodifyChatMessage.ai(text: 'hello'));
+
+      expect(user.author.id, userAuthor.id);
+      expect(ai.author.id, aiAuthor.id);
+    });
+  });
+
+  group('toFlyerMessages', () {
+    test('reverses the timeline to the newest-first order Flyer expects', () {
+      final timeline = [
+        CodifyChatMessage.user(text: 'first', id: 'a'),
+        CodifyChatMessage.ai(text: 'second', id: 'b'),
+      ];
+
+      final flyer = toFlyerMessages(timeline);
+
+      expect(flyer.map((m) => m.id), ['b', 'a']);
+    });
+  });
+}


### PR DESCRIPTION
- Embeddable chat widget
- AiChatController for message state, sending flow, and seenAt updates
- CodifyChatMessage model + mapping layer to Flyer Chat types
- Branded typing indicator using the existing AiProgressIndicator shimmer
- Text messaging support and attachment button to append test image/PDF messages
- Send button is disabled when input is empty or while AI is thinking.
- Error bubble handling
- Added responsive layout constraints so the chat stays centered and readable on large screens.
- Example screen added to the widget catalog
- New tests for controller behavior

Closes #32 