### PR TITLE
[#37] ✨ Added audio message handler + example screen

### DIFF
--- a/codifyiq_core_components/CHANGELOG.md
+++ b/codifyiq_core_components/CHANGELOG.md
@@ -10,6 +10,18 @@
   * Static `UserAvatar.initialsFor({displayName, email})` helper exposes the initials algorithm for mirroring elsewhere in consumer UI (menu headers, mentions, etc.)
 * New widgets: `GoogleSignInButton`, `AppleSignInButton`, and `MicrosoftSignInButton` — `SocialSignInButton` convenience wrappers preconfigured with provider-appropriate labels (`'Continue with Google'`, `'Continue with Apple'`, `'Continue with Microsoft'`) and Material Icons placeholder glyphs for `icon`, so they work out of the box for prototyping. Production consumers should override `icon` with the official brand asset (trademarked logos cannot be bundled in the published package); class dartdocs link directly to each provider's branding guidelines
 * `AppleSignInButton` enforces Apple's black-on-light / white-on-dark icon rule by wrapping the supplied `icon` in an `IconTheme` whose color is derived from the ambient theme brightness — plain `Icon` widgets pick it up automatically; non-`Icon` assets read from `IconTheme.of(context)`. New `AppleIconBrightness` enum lets the caller override the auto-detected brightness via `iconBrightness:` (e.g. for buttons placed on backgrounds that diverge from the surrounding theme)
+* New widget: `AudioMessageWidget` — a self-contained audio player for chat messages
+  * Play/pause button, scrubbing slider, and elapsed/total duration readout
+  * Four clearly differentiated states: idle (ready to play), loading (buffering), playing, and error
+  * Accepts an HTTP/HTTPS URL or local file path via `url`
+  * Optional `controller` parameter to inject an external `AudioMessageController` — omit it to let the widget manage its own lifecycle
+  * All colors sourced from `Theme.of(context).colorScheme` for full Material 3 support
+* New class: `AudioMessageController` — `ChangeNotifier` backed by a pluggable `AudioPlayerBackend`
+  * Exposes `state` (`AudioPlaybackState` enum), `position`, `duration`, and `progress` fraction
+  * Methods: `play()`, `pause()`, `seek(double progress)`
+  * Lazily loads the URL on first `play()` call; subsequent calls resume from the paused position
+  * Stops when the audio completes; tapping play again restarts from the beginning
+* `AudioMessageController` leverages `just_audio` via the default `JustAudioPlayerBackend`; supply a custom `AudioPlayerBackend` to swap the audio engine
 * New widget set: `NotificationBellButton`, `NotificationCenterPanel`, `NotificationCenterPage`, and `NotificationCenterController` — a Play Store-style notification center for tracking long-running, user-initiated tasks
   * App-bar bell with a stoplight-coded Material 3 badge — amber while work is in flight, green when every tracked item completed, and red when at least one item failed (failure always wins so a regression is never hidden behind an in-progress indicator)
   * Bell icon swaps to a filled variant whenever items are tracked, so state is conveyed by shape as well as color (WCAG 1.4.1)

--- a/codifyiq_core_components/example/lib/audio_message_example.dart
+++ b/codifyiq_core_components/example/lib/audio_message_example.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:codifyiq_core_components/codifyiq_core_components.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:flutter_chat_ui/flutter_chat_ui.dart';
+
+/// Throwaway demo screen showing [AudioMessageWidget] integrated with the
+/// standard Flyer Chat [Chat] widget.
+///
+/// Renders a static conversation with mixed text and audio messages.
+/// The [Builders.audioMessageBuilder] wires each [AudioMessage.source] to
+/// an [AudioMessageWidget] wrapped in a theme-tinted bubble.
+class AudioMessageExample extends StatefulWidget {
+  /// Creates an [AudioMessageExample].
+  const AudioMessageExample({super.key});
+
+  @override
+  State<AudioMessageExample> createState() => _AudioMessageExampleState();
+}
+
+class _AudioMessageExampleState extends State<AudioMessageExample> {
+  static const _meId = 'me';
+  static const _themId = 'them';
+
+  static const _me = User(id: _meId, name: 'You');
+  static const _them = User(id: _themId, name: 'Alex');
+
+  late final InMemoryChatController _chatController;
+
+  @override
+  void initState() {
+    super.initState();
+    _chatController = InMemoryChatController();
+
+    // setMessages expects oldest-first (index 0 = top, last index = bottom/newest).
+    unawaited(_chatController.setMessages([
+      const Message.text(
+        id: 'msg-1',
+        authorId: _themId,
+        text: 'Hey! Check out this voice note.',
+      ),
+      Message.audio(
+        id: 'msg-2',
+        authorId: _themId,
+        source: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
+        duration: const Duration(minutes: 7, seconds: 13),
+        createdAt: DateTime.now().subtract(const Duration(minutes: 3)),
+      ),
+      const Message.text(
+        id: 'msg-3',
+        authorId: _meId,
+        text: "Nice, here's one from my end:",
+      ),
+      Message.audio(
+        id: 'msg-4',
+        authorId: _meId,
+        source: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3',
+        duration: const Duration(minutes: 4, seconds: 8),
+        createdAt: DateTime.now().subtract(const Duration(minutes: 1)),
+      ),
+      const Message.text(
+        id: 'msg-5',
+        authorId: _themId,
+        text: '(Broken URL below — tap the error icon to test retry)',
+      ),
+      Message.audio(
+        id: 'msg-6',
+        authorId: _themId,
+        source: 'https://example.com/does-not-exist.mp3',
+        duration: const Duration(seconds: 30),
+        createdAt: DateTime.now(),
+      ),
+    ]));
+  }
+
+  @override
+  void dispose() {
+    _chatController.dispose();
+    super.dispose();
+  }
+
+  Future<User?> _resolveUser(String id) async => id == _meId ? _me : _them;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Audio Message')),
+      body: Chat(
+        currentUserId: _meId,
+        resolveUser: _resolveUser,
+        chatController: _chatController,
+        theme: ChatTheme.fromThemeData(Theme.of(context)),
+        builders: Builders(
+          audioMessageBuilder:
+              (context, message, index, {required isSentByMe, groupStatus}) {
+                return _AudioBubble(
+                  url: message.source,
+                  isSentByMe: isSentByMe,
+                );
+              },
+        ),
+      ),
+    );
+  }
+}
+
+/// A styled container that wraps [AudioMessageWidget] in a chat bubble.
+class _AudioBubble extends StatelessWidget {
+  const _AudioBubble({required this.url, required this.isSentByMe});
+
+  final String url;
+  final bool isSentByMe;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      margin: const EdgeInsets.all(2),
+      decoration: BoxDecoration(
+        color: isSentByMe
+            ? colorScheme.primaryContainer
+            : colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: AudioMessageWidget(url: url),
+    );
+  }
+}

--- a/codifyiq_core_components/example/lib/router.dart
+++ b/codifyiq_core_components/example/lib/router.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'ai_progress_indicator_example.dart';
+import 'audio_message_example.dart';
 import 'error_retry_widget_example.dart';
 import 'notification_center_example.dart';
 import 'pdf_viewer_widget_example.dart';
@@ -81,6 +82,12 @@ ShellRoute _getMainApplicationShellRoute() {
         path: "/image-viewer",
         builder: (BuildContext context, GoRouterState state) {
           return ImageViewerWidgetExample();
+        },
+      ),
+      GoRoute(
+        path: "/audio-message",
+        builder: (BuildContext context, GoRouterState state) {
+          return const AudioMessageExample();
         },
       ),
     ],

--- a/codifyiq_core_components/example/lib/widget_catalog.dart
+++ b/codifyiq_core_components/example/lib/widget_catalog.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 
 import 'ai_progress_indicator_example.dart';
+import 'audio_message_example.dart';
 import 'error_retry_widget_example.dart';
+import 'image_viewer_widget_example.dart';
 import 'notification_center_example.dart';
 import 'pdf_viewer_widget_example.dart';
 import 'social_sign_in_screen_example.dart';
 import 'terms_and_conditions_widget_example.dart';
-import 'image_viewer_widget_example.dart';
 import 'user_avatar_example.dart';
 
 class WidgetCatalog extends StatelessWidget {
@@ -58,6 +59,12 @@ class WidgetCatalog extends StatelessWidget {
       'description':
           'PDF viewer with zoom, page indicator, and optional text search',
       'route': PdfViewerWidgetExample(),
+    },
+    {
+      'name': 'Audio Message',
+      'description':
+          'Chat-style audio message player with play/pause, progress, and duration',
+      'route': AudioMessageExample(),
     },
   ];
 

--- a/codifyiq_core_components/example/pubspec.yaml
+++ b/codifyiq_core_components/example/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
     path: ../
   adaptive_theme: ^3.7.0
   go_router: ^17.1.0
+  flutter_chat_ui: ^2.11.0
+  flutter_chat_core: ^2.9.0
 
 dev_dependencies:
   flutter_test:

--- a/codifyiq_core_components/lib/codifyiq_core_components.dart
+++ b/codifyiq_core_components/lib/codifyiq_core_components.dart
@@ -15,3 +15,6 @@ export 'widgets/image_viewer_widget.dart';
 export 'widgets/social_sign_in_screen.dart';
 export 'widgets/terms_and_conditions_widget.dart';
 export 'widgets/user_avatar.dart';
+export 'widgets/audio_message/audio_player_backend.dart';
+export 'widgets/audio_message/audio_message_controller.dart';
+export 'widgets/audio_message/audio_message.dart';

--- a/codifyiq_core_components/lib/src/audio_message/just_audio_player_backend.dart
+++ b/codifyiq_core_components/lib/src/audio_message/just_audio_player_backend.dart
@@ -1,0 +1,65 @@
+import 'package:just_audio/just_audio.dart';
+
+import '../../widgets/audio_message/audio_player_backend.dart';
+
+/// [AudioPlayerBackend] implementation backed by [just_audio]'s [AudioPlayer].
+///
+/// This is the default backend used by [AudioMessageController] when no
+/// custom [AudioPlayerBackend] is supplied.
+class JustAudioPlayerBackend implements AudioPlayerBackend {
+  final AudioPlayer _player = AudioPlayer();
+
+  @override
+  Stream<AudioBackendState> get stateStream {
+    AudioBackendState? last;
+    return _player.playerStateStream
+        .map(
+          (s) => AudioBackendState(
+            processingState: _toProcessingState(s.processingState),
+            isPlaying: s.playing,
+          ),
+        )
+        .where((s) {
+          if (s == last) return false;
+          last = s;
+          return true;
+        });
+  }
+
+  @override
+  Stream<Duration> get positionStream => _player.positionStream;
+
+  @override
+  Stream<Duration?> get durationStream => _player.durationStream;
+
+  @override
+  Future<void> setUrl(String url) async {
+    await _player.setUrl(url);
+  }
+
+  @override
+  Future<void> play() => _player.play();
+
+  @override
+  Future<void> pause() => _player.pause();
+
+  @override
+  Future<void> seek(Duration position) => _player.seek(position);
+
+  @override
+  Future<void> stop() => _player.stop();
+
+  @override
+  void dispose() => _player.dispose();
+
+  static AudioBackendProcessingState _toProcessingState(
+    ProcessingState state,
+  ) =>
+      switch (state) {
+        ProcessingState.idle => AudioBackendProcessingState.idle,
+        ProcessingState.loading => AudioBackendProcessingState.loading,
+        ProcessingState.buffering => AudioBackendProcessingState.buffering,
+        ProcessingState.ready => AudioBackendProcessingState.ready,
+        ProcessingState.completed => AudioBackendProcessingState.completed,
+      };
+}

--- a/codifyiq_core_components/lib/widgets/audio_message/audio_message.dart
+++ b/codifyiq_core_components/lib/widgets/audio_message/audio_message.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/material.dart';
+
+import 'audio_message_controller.dart';
+
+/// A self-contained audio message player widget.
+///
+/// Displays a play/pause button, a scrubbing [Slider], and an
+/// elapsed / total duration readout. Handles loading, playing, paused,
+/// and error states using theme-aware colors.
+///
+/// Supply a [controller] to share playback state across multiple widgets
+/// (e.g., to stop one track when another starts). Omit it to let the
+/// widget create and manage its own [AudioMessageController] lifecycle.
+///
+/// ```dart
+/// AudioMessageWidget(
+///   url: 'https://example.com/audio.mp3',
+/// )
+/// ```
+class AudioMessageWidget extends StatefulWidget {
+  /// Creates an [AudioMessageWidget].
+  ///
+  /// [url] is the audio source — an HTTP/HTTPS URL or a local file path.
+  /// Ignored when [controller] is supplied; ensure they match to avoid
+  /// confusion.
+  const AudioMessageWidget({
+    super.key,
+    required this.url,
+    this.controller,
+    this.errorLabel = 'Could not load audio',
+    this.playTooltip = 'Play',
+    this.pauseTooltip = 'Pause',
+    this.retryTooltip = 'Retry',
+  });
+
+  /// Audio source URL or file path. Ignored when [controller] is provided.
+  final String url;
+
+  /// Optional external controller. When omitted the widget creates and
+  /// disposes its own [AudioMessageController].
+  final AudioMessageController? controller;
+
+  /// Label shown below the error icon. Defaults to `'Could not load audio'`.
+  final String errorLabel;
+
+  /// Tooltip for the play button. Defaults to `'Play'`.
+  final String playTooltip;
+
+  /// Tooltip for the pause button. Defaults to `'Pause'`.
+  final String pauseTooltip;
+
+  /// Tooltip for the retry button shown on error. Defaults to `'Retry'`.
+  final String retryTooltip;
+
+  @override
+  State<AudioMessageWidget> createState() => _AudioMessageWidgetState();
+}
+
+class _AudioMessageWidgetState extends State<AudioMessageWidget> {
+  late AudioMessageController _controller;
+  bool _ownsController = false;
+
+  @override
+  void initState() {
+    super.initState();
+    assert(
+      widget.controller == null || widget.controller!.url == widget.url,
+      'url is ignored when controller is provided; ensure they match or omit url.',
+    );
+    if (widget.controller != null) {
+      _controller = widget.controller!;
+    } else {
+      _controller = AudioMessageController(widget.url);
+      _ownsController = true;
+    }
+  }
+
+  @override
+  void didUpdateWidget(AudioMessageWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    final newExternal = widget.controller;
+
+    if (newExternal != null) {
+      // Switching to (or staying on) an external controller.
+      if (_ownsController) {
+        _controller.dispose();
+        _ownsController = false;
+      }
+      _controller = newExternal;
+    } else if (!_ownsController) {
+      // Switching from external to owned.
+      _controller = AudioMessageController(widget.url);
+      _ownsController = true;
+    } else if (widget.url != oldWidget.url) {
+      // Still owned but URL changed — recreate for the new source.
+      _controller.dispose();
+      _controller = AudioMessageController(widget.url);
+    }
+  }
+
+  @override
+  void dispose() {
+    if (_ownsController) _controller.dispose();
+    super.dispose();
+  }
+
+  static String _fmt(Duration d) {
+    final h = d.inHours;
+    final m = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final s = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return h > 0 ? '$h:$m:$s' : '$m:$s';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return ListenableBuilder(
+      listenable: _controller,
+      builder: (context, _) {
+        final state = _controller.state;
+        final isInteractive =
+            state != AudioPlaybackState.idle &&
+            state != AudioPlaybackState.error;
+
+        return ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 220, maxWidth: 340),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.max,
+                children: [
+                  _LeadingButton(
+                    state: state,
+                    primaryColor: colorScheme.primary,
+                    errorColor: colorScheme.error,
+                    onPlay: () { _controller.play(); },
+                    onPause: () { _controller.pause(); },
+                    playTooltip: widget.playTooltip,
+                    pauseTooltip: widget.pauseTooltip,
+                    retryTooltip: widget.retryTooltip,
+                  ),
+                  Expanded(
+                    child: SliderTheme(
+                      data: SliderTheme.of(context).copyWith(
+                        trackHeight: 2,
+                        thumbShape: const RoundSliderThumbShape(
+                          enabledThumbRadius: 6,
+                        ),
+                        overlayShape: const RoundSliderOverlayShape(
+                          overlayRadius: 12,
+                        ),
+                      ),
+                      child: Slider(
+                        value: _controller.progress,
+                        onChanged: isInteractive
+                            ? (v) => _controller.seek(v)
+                            : null,
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(right: 8),
+                    child: Text(
+                      '${_fmt(_controller.position)} / ${_fmt(_controller.duration)}',
+                      style: textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                        fontFeatures: const [FontFeature.tabularFigures()],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              if (state == AudioPlaybackState.error)
+                Padding(
+                  padding: const EdgeInsets.only(left: 16, bottom: 6),
+                  child: Text(
+                    widget.errorLabel,
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colorScheme.error,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// The leading control — spinner while loading, play/pause while ready,
+/// error icon on failure.
+class _LeadingButton extends StatelessWidget {
+  const _LeadingButton({
+    required this.state,
+    required this.primaryColor,
+    required this.errorColor,
+    required this.onPlay,
+    required this.onPause,
+    required this.playTooltip,
+    required this.pauseTooltip,
+    required this.retryTooltip,
+  });
+
+  final AudioPlaybackState state;
+  final Color primaryColor;
+  final Color errorColor;
+  final VoidCallback onPlay;
+  final VoidCallback onPause;
+  final String playTooltip;
+  final String pauseTooltip;
+  final String retryTooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 48,
+      height: 48,
+      child: switch (state) {
+        AudioPlaybackState.loading => Center(
+          child: SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(
+              strokeWidth: 2.5,
+              color: primaryColor,
+            ),
+          ),
+        ),
+        AudioPlaybackState.error => IconButton(
+          icon: const Icon(Icons.error_outline),
+          color: errorColor,
+          iconSize: 28,
+          onPressed: onPlay,
+          tooltip: retryTooltip,
+        ),
+        AudioPlaybackState.playing => IconButton(
+          icon: const Icon(Icons.pause),
+          color: primaryColor,
+          iconSize: 28,
+          onPressed: onPause,
+          tooltip: pauseTooltip,
+        ),
+        _ => IconButton(
+          icon: const Icon(Icons.play_arrow),
+          color: primaryColor,
+          iconSize: 28,
+          onPressed: onPlay,
+          tooltip: playTooltip,
+        ),
+      },
+    );
+  }
+}

--- a/codifyiq_core_components/lib/widgets/audio_message/audio_message_controller.dart
+++ b/codifyiq_core_components/lib/widgets/audio_message/audio_message_controller.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+import 'dart:developer' as dev;
+
+import 'package:flutter/foundation.dart';
+
+import 'audio_player_backend.dart';
+import '../../src/audio_message/just_audio_player_backend.dart';
+
+/// Playback states for [AudioMessageController].
+enum AudioPlaybackState {
+  /// No audio loaded; player is at rest.
+  idle,
+
+  /// Audio is being fetched or buffered.
+  loading,
+
+  /// Audio is actively playing.
+  playing,
+
+  /// Audio is loaded and paused.
+  paused,
+
+  /// A playback error occurred; see [AudioMessageController.rawError].
+  error,
+}
+
+/// State container for a single audio message playback session.
+///
+/// Wraps an [AudioPlayerBackend] and exposes a simplified
+/// [AudioPlaybackState] enum, current [position], total [duration], and
+/// [progress] fraction — all driven by the underlying backend streams.
+///
+/// Typical lifecycle:
+/// 1. Create a controller with the audio [url].
+/// 2. Call [play] — the URL is fetched on the first call (state → loading).
+/// 3. Call [pause] / [play] to toggle; [seek] to jump to a position.
+/// 4. Dispose the controller when the owning widget is removed.
+///
+/// Pass a custom [backend] to substitute the default `just_audio` binding —
+/// useful for testing or platforms where `just_audio` is unavailable.
+///
+/// This controller is **UI-only**: it does not manage downloads, caching,
+/// or upload — consumers wire it to their own data layer.
+class AudioMessageController extends ChangeNotifier {
+  /// Creates a controller for the audio at [url].
+  ///
+  /// [backend] defaults to [JustAudioPlayerBackend]. Supply a custom
+  /// implementation to swap the audio engine or inject a test double.
+  AudioMessageController(this.url, {AudioPlayerBackend? backend})
+      : _backend = backend ?? JustAudioPlayerBackend() {
+    _listenToBackend();
+  }
+
+  /// The audio source URL (HTTP/HTTPS) or local file path.
+  final String url;
+
+  final AudioPlayerBackend _backend;
+  final List<StreamSubscription<dynamic>> _subscriptions = [];
+
+  bool _initialized = false;
+  bool _disposed = false;
+  bool _completedOnce = false;
+  AudioPlaybackState _state = AudioPlaybackState.idle;
+  Duration _position = Duration.zero;
+  Duration _duration = Duration.zero;
+  String? _rawError;
+
+  /// Raw platform error string when [state] is [AudioPlaybackState.error].
+  /// Intended for logging only — may contain URLs or internal error codes.
+  /// Display a fixed friendly message to users instead.
+  String? get rawError => _rawError;
+
+  /// Current playback state.
+  AudioPlaybackState get state => _state;
+
+  /// Current playback position.
+  Duration get position => _position;
+
+  /// Total duration of the audio. Zero until the URL is loaded.
+  Duration get duration => _duration;
+
+  /// Playback progress in [0, 1]. Zero until the URL is loaded.
+  double get progress => _duration.inMilliseconds == 0
+      ? 0.0
+      : (_position.inMilliseconds / _duration.inMilliseconds).clamp(0.0, 1.0);
+
+  /// Loads the URL (on first call) then starts playback.
+  ///
+  /// No-ops while [state] is [AudioPlaybackState.loading] or
+  /// [AudioPlaybackState.playing]. Calling [play] from
+  /// [AudioPlaybackState.error] clears the error and retries the load.
+  /// After audio completes, [play] seeks to the start and replays without
+  /// re-fetching the URL.
+  Future<void> play() async {
+    if (_disposed ||
+        _state == AudioPlaybackState.loading ||
+        _state == AudioPlaybackState.playing) {
+      return;
+    }
+
+    _rawError = null;
+
+    if (!_initialized) {
+      _initialized = true;
+      try {
+        await _backend.setUrl(url);
+      } catch (e) {
+        _initialized = false;
+        _state = AudioPlaybackState.error;
+        _rawError = e.toString();
+        dev.log(_rawError!, name: 'AudioMessageController', level: 900);
+        notifyListeners();
+        return;
+      }
+    } else if (_completedOnce) {
+      _completedOnce = false;
+      await _backend.seek(Duration.zero);
+    }
+
+    if (_disposed) return;
+    await _backend.play();
+  }
+
+  /// Pauses playback. No-op when not playing or disposed.
+  Future<void> pause() async {
+    if (_disposed) return;
+    await _backend.pause();
+  }
+
+  /// Seeks to [progress] ∈ [0, 1] of the total duration.
+  ///
+  /// No-op when disposed, duration unknown, or an error occurred.
+  Future<void> seek(double progress) async {
+    if (_disposed) return;
+    if (_duration == Duration.zero || _state == AudioPlaybackState.error) {
+      return;
+    }
+    final target = Duration(
+      milliseconds: (_duration.inMilliseconds * progress.clamp(0.0, 1.0))
+          .round(),
+    );
+    await _backend.seek(target);
+  }
+
+  void _listenToBackend() {
+    _subscriptions.add(_backend.stateStream.listen(_onBackendState));
+    _subscriptions.add(
+      _backend.positionStream.listen((pos) {
+        if (_disposed) return;
+        _position = pos;
+        notifyListeners();
+      }),
+    );
+    _subscriptions.add(
+      _backend.durationStream.listen((dur) {
+        if (_disposed) return;
+        if (dur != null) {
+          _duration = dur;
+          notifyListeners();
+        }
+      }),
+    );
+  }
+
+  void _onBackendState(AudioBackendState backendState) {
+    if (_disposed) return;
+    switch (backendState.processingState) {
+      case AudioBackendProcessingState.idle:
+        _state = AudioPlaybackState.idle;
+      case AudioBackendProcessingState.loading:
+      case AudioBackendProcessingState.buffering:
+        _state = AudioPlaybackState.loading;
+      case AudioBackendProcessingState.ready:
+        _state = backendState.isPlaying
+            ? AudioPlaybackState.playing
+            : AudioPlaybackState.paused;
+      case AudioBackendProcessingState.completed:
+        _completedOnce = true;
+        _state = AudioPlaybackState.idle;
+        _position = Duration.zero;
+    }
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    for (final sub in _subscriptions) {
+      sub.cancel();
+    }
+    _backend.dispose();
+    super.dispose();
+  }
+}

--- a/codifyiq_core_components/lib/widgets/audio_message/audio_player_backend.dart
+++ b/codifyiq_core_components/lib/widgets/audio_message/audio_player_backend.dart
@@ -1,0 +1,77 @@
+/// Processing states emitted by [AudioPlayerBackend.stateStream].
+enum AudioBackendProcessingState {
+  /// Player is idle — no source loaded.
+  idle,
+
+  /// Source is being fetched.
+  loading,
+
+  /// Source is loaded but buffering.
+  buffering,
+
+  /// Source is ready for playback.
+  ready,
+
+  /// Playback has reached the end of the source.
+  completed,
+}
+
+/// Snapshot of backend player state emitted by [AudioPlayerBackend.stateStream].
+class AudioBackendState {
+  /// Creates an [AudioBackendState].
+  const AudioBackendState({
+    required this.processingState,
+    required this.isPlaying,
+  });
+
+  /// Current processing state of the underlying player.
+  final AudioBackendProcessingState processingState;
+
+  /// Whether the player is actively playing audio.
+  final bool isPlaying;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AudioBackendState &&
+          processingState == other.processingState &&
+          isPlaying == other.isPlaying;
+
+  @override
+  int get hashCode => Object.hash(processingState, isPlaying);
+}
+
+/// Pluggable audio player interface consumed by [AudioMessageController].
+///
+/// Implement this to swap the default `just_audio` binding for a different
+/// engine, a platform-specific player, or a test double.
+///
+/// The default implementation is [JustAudioPlayerBackend].
+abstract interface class AudioPlayerBackend {
+  /// Stream of player state snapshots.
+  Stream<AudioBackendState> get stateStream;
+
+  /// Stream of current playback position.
+  Stream<Duration> get positionStream;
+
+  /// Stream of total audio duration. Emits [null] when unknown.
+  Stream<Duration?> get durationStream;
+
+  /// Loads the audio source at [url].
+  Future<void> setUrl(String url);
+
+  /// Starts or resumes playback.
+  Future<void> play();
+
+  /// Pauses playback.
+  Future<void> pause();
+
+  /// Seeks to [position].
+  Future<void> seek(Duration position);
+
+  /// Stops playback and releases the current source.
+  Future<void> stop();
+
+  /// Releases all resources held by this backend.
+  void dispose();
+}

--- a/codifyiq_core_components/pubspec.yaml
+++ b/codifyiq_core_components/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   shimmer: ^3.0.0
   pdfrx: ^2.3.3
   photo_view: ^0.15.0
+  just_audio: ^0.10.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Summary

  - Adds AudioMessageWidget: self-contained audio player for chat messages with play/pause, scrubbing slider, and elapsed/total duration readout
  - Adds AudioMessageController: ChangeNotifier wrapping just_audio's AudioPlayer, exposing state, position, duration, and progress
  - Adds a throwaway example screen wired into Flyer Chat's Chat widget via Builders.audioMessageBuilder

  Test plan

  - Navigate to "Audio Message" in the widget catalog
  - Tap play on an audio bubble → loading spinner appears, then audio plays
  - Tap pause → audio pauses; tap play → resumes from same position
  - Drag the slider → seeks to that position
  - Let audio play to the end → returns to idle state (play button, zeroed slider)
  - Verify bubbles respect the app theme (light/dark)
  
  Closes #37 