### PR TITLE
[#55][#56][#57][#58][#59] :sparkles: pdf_viewer 1.1.0: range access, …

### DIFF
--- a/example/lib/pdf_viewer_widget_example.dart
+++ b/example/lib/pdf_viewer_widget_example.dart
@@ -25,8 +25,12 @@ class PdfViewerWidgetExample extends StatefulWidget {
 class _PdfViewerWidgetExampleState extends State<PdfViewerWidgetExample> {
   bool _enableSearch = true;
 
+  // A ~5 MB public-domain sample, hosted on GitHub raw so it sends CORS and a
+  // Content-Length (making the download progress bar determinate) and supports
+  // range requests. Large enough that the progress bar is visible while it
+  // loads.
   static final Uri _sampleUri = Uri.parse(
-    'https://raw.githubusercontent.com/mozilla/pdf.js/master/test/pdfs/tracemonkey.pdf',
+    'https://raw.githubusercontent.com/py-pdf/sample-files/main/009-pdflatex-geotopo/GeoTopo.pdf',
   );
 
   @override
@@ -44,11 +48,33 @@ class _PdfViewerWidgetExampleState extends State<PdfViewerWidgetExample> {
           const BrightnessButton(),
         ],
       ),
+      // preferRangeAccess is left false here so pdfrx downloads the whole file
+      // before first render, which showcases the determinate download progress
+      // bar. Set it to true to instead stream the document via HTTP range
+      // requests — the first page then renders after a single small request, so
+      // the progress bar barely appears. See the package README for the
+      // trade-off.
+      //
+      // useProgressiveLoading (on by default) hands back pages as the document
+      // parses; combined with preferRangeAccess: true it yields true on-demand,
+      // page-by-page loading of a large remote PDF.
       body: PdfViewerWidget(
-        source: PdfSource.uri(_sampleUri),
+        source: PdfSource.uri(
+          _sampleUri,
+          preferRangeAccess: false,
+          useProgressiveLoading: true,
+        ),
         enableSearch: _enableSearch,
+        // Open to a specific page (1 = default; e.g. from a deep link) and fail
+        // a stalled network load after 30s instead of spinning forever.
+        initialPageNumber: 1,
+        networkTimeout: const Duration(seconds: 30),
         onDocumentLoaded: (pageCount) => debugPrint('Loaded $pageCount pages'),
         onPageChanged: (page) => debugPrint('On page $page'),
+        // The built-in progress bar across the top of the viewer is shown by
+        // default; this callback additionally reports raw byte counts.
+        onDownloadProgress: (received, total) =>
+            debugPrint('Downloaded $received / ${total ?? '?'} bytes'),
         errorBuilder: (context, error) => Center(
           child: Padding(
             padding: const EdgeInsets.all(24),

--- a/packages/codifyiq_pdf_viewer/CHANGELOG.md
+++ b/packages/codifyiq_pdf_viewer/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0
+
+* `PdfSource.uri` gains a `preferRangeAccess` flag (default `false`). When enabled, the viewer streams a network PDF via HTTP range requests instead of downloading it in full first, so the first page of a large document renders after a single small request. Servers that don't support range requests fall back to a full download automatically. No effect on web.
+* `PdfViewerWidget` now shows a linear download progress bar across the top of the viewer while a network PDF loads — determinate when the server reports a content length, indeterminate otherwise. Disable it with `showDownloadProgress: false`, and/or pass `onDownloadProgress: (received, total) { ... }` to drive your own progress UI.
+* `PdfSource.uri` gains a `useProgressiveLoading` flag (default `true`) that hands back pages as the document parses instead of only after the whole file is available. Combined with `preferRangeAccess: true` and a linearized ("Fast Web View") PDF, later pages of a large remote document can render before the download finishes; non-linearized PDFs still need a near-complete download first.
+* `PdfViewerWidget` gains an `initialPageNumber` (default `1`) to open a document to a specific page — handy for deep links or resuming where the reader left off. Applies to all source types.
+* `PdfViewerWidget` gains a `networkTimeout` (default 30 seconds) for `PdfSource.uri`: if a network request fails to start responding within the window it surfaces the error UI instead of waiting forever. It bounds the response start (connect + headers) per request, not the total download time.
+
 ## 1.0.0
 
 * Initial release as a standalone package, extracted from `codifyiq_core_components`.

--- a/packages/codifyiq_pdf_viewer/README.md
+++ b/packages/codifyiq_pdf_viewer/README.md
@@ -2,8 +2,41 @@
 
 [![pub package](https://img.shields.io/pub/v/codifyiq_pdf_viewer.svg)](https://pub.dev/packages/codifyiq_pdf_viewer)
 
-A reusable PDF viewer backed by [`pdfrx`](https://pub.dev/packages/pdfrx). Renders a document
-from a network URI, a local file path, or in-memory bytes via a single `PdfSource` parameter.
+A reusable PDF viewer backed by [`pdfrx`](https://pub.dev/packages/pdfrx). Renders a document from a network URI, a local file 
+path, or in-memory bytes via a single `PdfSource` parameter.
+
+## Demo
+Select the image for a quick walkthrough:
+[![Watch the pdf viewer in action](doc/codifyiq_pdf_viewer_demo.png)](https://drive.google.com/file/d/1AEjjMeh-RJJTUQ7mIArs1lDOepIlDDQ8/view?usp=drive_link)
+
+## Features
+
+* **Built-in search UI** — a Material search bar, debounced input, match counter, and
+  next/previous controls that wrap around at both ends.
+* **Consistent zoom bounds** — the `minScale` / `maxScale` you pass are honored by pinch,
+  +/− buttons, and Ctrl/Cmd + scroll-wheel alike.
+* **On-screen web zoom buttons** and a **page indicator overlay**.
+* **A unified `PdfSource`** (value-equal variants) in place of `pdfrx`'s separate
+  `.uri` / `.file` / `.data` constructors, so swapping documents at runtime diffs cleanly.
+* **On-demand streaming for network PDFs** — opt in with `preferRangeAccess` to fetch only
+  the byte ranges the viewport needs, so the first page of a large document renders without
+  waiting for the whole file to download. Pair it with `useProgressiveLoading` (on by
+  default) so later pages resolve before the download finishes instead of all at once.
+* **Download progress** — a linear progress bar (determinate when the server sends a content
+  length) is shown across the top of the viewer while a network PDF loads; opt out with
+  `showDownloadProgress: false` or hook `onDownloadProgress` to drive your own UI.
+* **Open to a page** — `initialPageNumber` opens the document to a specific page (deep links,
+  resuming a reader), and `networkTimeout` bounds a stalled network load so it surfaces the
+  error UI instead of spinning forever.
+
+## Installation
+
+```yaml
+dependencies:
+  codifyiq_pdf_viewer: ^1.1.0
+```
+
+## Usage
 
 ```dart
 import 'package:codifyiq_pdf_viewer/codifyiq_pdf_viewer.dart';
@@ -15,22 +48,14 @@ PdfViewerWidget(
 );
 ```
 
-## What this adds on top of `pdfrx`
+Load from a local file or in-memory bytes with the other `PdfSource` variants:
 
-* **Built-in search UI** — a Material search bar, debounced input, match counter, and
-  next/previous controls that wrap around at both ends.
-* **Consistent zoom bounds** — the `minScale` / `maxScale` you pass are honored by pinch,
-  +/− buttons, and Ctrl/Cmd + scroll-wheel alike.
-* **On-screen web zoom buttons** and a **page indicator overlay**.
-* **A unified `PdfSource`** (value-equal variants) in place of `pdfrx`'s separate
-  `.uri` / `.file` / `.data` constructors, so swapping documents at runtime diffs cleanly.
-
-## Installation
-
-```yaml
-dependencies:
-  codifyiq_pdf_viewer: ^1.0.0
+```dart
+PdfViewerWidget(source: PdfSource.file('/path/to/file.pdf'));
+PdfViewerWidget(source: PdfSource.bytes(myUint8List));
 ```
+
+## Authentication
 
 For PDFs behind an authenticated endpoint, pass HTTP headers via `PdfSource.uri`:
 
@@ -42,6 +67,47 @@ PdfViewerWidget(
   ),
 );
 ```
+
+## Streaming large PDFs
+
+Set `preferRangeAccess: true` on `PdfSource.uri` to render the first page after a single
+small request instead of downloading the entire file first:
+
+```dart
+PdfViewerWidget(
+  source: PdfSource.uri(
+    Uri.parse('https://example.com/large-report.pdf'),
+    preferRangeAccess: true,
+  ),
+);
+```
+
+The server must answer range requests with `206 Partial Content`; if it doesn't, `pdfrx`
+falls back to a full download automatically, so enabling this is safe even when range
+support is unknown. It's a load-time choice applied when the document first opens, and it
+has no effect on web.
+
+For a large, multi-page document you usually want range access **and** progressive loading
+(the latter is on by default) so later pages render before the whole file arrives:
+
+```dart
+PdfViewerWidget(
+  source: PdfSource.uri(
+    Uri.parse('https://example.com/large-report.pdf'),
+    preferRangeAccess: true,
+    useProgressiveLoading: true, // default; shown for clarity
+  ),
+);
+```
+
+> **Requires a linearized PDF.** True page-by-page streaming only works when the document is
+> **linearized** ("Fast Web View") — a layout that puts a hint table and the first page at the
+> front of the file. A non-linearized PDF keeps its cross-reference table and object streams
+> at the *end*, so pages past the first can't resolve until (essentially) the whole file has
+> been fetched, even with `preferRangeAccess: true`. In that case you'll see the first page,
+> then the rest appear together once the download completes. Linearize your PDFs at
+> ingest/build time — e.g. `qpdf --linearize in.pdf out.pdf` — to get incremental page
+> loading; it's a one-time step and doesn't change how they render otherwise.
 
 > **Web note:** PDFs loaded via `PdfSource.uri` require the server to send appropriate CORS
 > headers. `PdfSource.file` is not supported on the web platform.

--- a/packages/codifyiq_pdf_viewer/lib/src/pdf_source.dart
+++ b/packages/codifyiq_pdf_viewer/lib/src/pdf_source.dart
@@ -18,9 +18,33 @@ sealed class PdfSource {
   /// authorization headers here (e.g. a JWT bearer token) for endpoints that
   /// require them.
   ///
+  /// When [preferRangeAccess] is `true`, the renderer fetches only the byte
+  /// ranges needed for the current viewport (via HTTP range requests) instead
+  /// of downloading the whole document up front, so the first page of a large
+  /// PDF renders after a single small request. The server must respond with
+  /// `206 Partial Content`; if it doesn't, the renderer falls back to a full
+  /// download automatically, so enabling this is safe even for servers that
+  /// don't support ranges. Ignored on web. Defaults to `false`.
+  ///
+  /// When [useProgressiveLoading] is `true` (the default), the renderer hands
+  /// back pages as the document structure resolves instead of waiting for the
+  /// whole file to parse, so later pages can render before the download
+  /// finishes. Pair it with [preferRangeAccess] for on-demand loading of a
+  /// large remote PDF.
+  ///
+  /// Incremental, page-by-page streaming only works on a **linearized**
+  /// ("Fast Web View") PDF. A non-linearized document keeps its cross-reference
+  /// table at the end of the file, so pages past the first can't resolve until
+  /// nearly the whole file has downloaded, even with [preferRangeAccess]. See
+  /// the package README for how to linearize.
+  ///
   /// On web, the target server must serve appropriate CORS headers.
-  const factory PdfSource.uri(Uri uri, {Map<String, String>? headers}) =
-      PdfUriSource;
+  const factory PdfSource.uri(
+    Uri uri, {
+    Map<String, String>? headers,
+    bool preferRangeAccess,
+    bool useProgressiveLoading,
+  }) = PdfUriSource;
 
   /// Loads a PDF from a local file path. Not supported on web.
   const factory PdfSource.file(String path) = PdfFileSource;
@@ -39,7 +63,18 @@ final class PdfUriSource extends PdfSource {
   ///
   /// [headers] are sent with the HTTP request — use this to supply
   /// authentication/authorization headers (e.g. a JWT bearer token).
-  const PdfUriSource(this.uri, {this.headers});
+  ///
+  /// When [preferRangeAccess] is `true`, the renderer streams the document via
+  /// HTTP range requests instead of downloading it in full up front. When
+  /// [useProgressiveLoading] is `true` (the default), pages resolve as the
+  /// document parses rather than only after the whole file is available. See
+  /// [PdfSource.uri] for details. Both are ignored on web.
+  const PdfUriSource(
+    this.uri, {
+    this.headers,
+    this.preferRangeAccess = false,
+    this.useProgressiveLoading = true,
+  });
 
   /// The URI to fetch the PDF from.
   final Uri uri;
@@ -47,12 +82,23 @@ final class PdfUriSource extends PdfSource {
   /// Optional HTTP headers sent with the request, e.g. for authentication.
   final Map<String, String>? headers;
 
+  /// Whether to fetch the document on demand via HTTP range requests rather
+  /// than downloading it in full before rendering. No effect on web.
+  final bool preferRangeAccess;
+
+  /// Whether pages are handed back progressively as the document parses,
+  /// instead of only once the full structure has resolved. Defaults to `true`.
+  /// No effect on web.
+  final bool useProgressiveLoading;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is PdfUriSource &&
           other.uri == uri &&
-          mapEquals(other.headers, headers));
+          mapEquals(other.headers, headers) &&
+          other.preferRangeAccess == preferRangeAccess &&
+          other.useProgressiveLoading == useProgressiveLoading);
 
   @override
   int get hashCode => Object.hash(
@@ -62,6 +108,8 @@ final class PdfUriSource extends PdfSource {
         : Object.hashAllUnordered(
             headers!.entries.map((e) => Object.hash(e.key, e.value)),
           ),
+    preferRangeAccess,
+    useProgressiveLoading,
   );
 }
 

--- a/packages/codifyiq_pdf_viewer/lib/src/pdf_viewer_widget.dart
+++ b/packages/codifyiq_pdf_viewer/lib/src/pdf_viewer_widget.dart
@@ -29,6 +29,14 @@ import 'pdf_source.dart';
 /// previous controls. A status label indicates the current match position or
 /// "No matches" when the query has no hits.
 ///
+/// ## Loading
+///
+/// For a network [PdfSource.uri], a linear progress bar is shown across the top
+/// of the viewer while the document downloads — determinate when the server
+/// reports a content length, indeterminate otherwise. Set
+/// [showDownloadProgress] to `false` to suppress it, and/or supply
+/// [onDownloadProgress] to drive a custom UI.
+///
 /// ## Error handling
 ///
 /// If [errorBuilder] is provided it replaces the default in-viewer error
@@ -42,13 +50,18 @@ class PdfViewerWidget extends StatefulWidget {
     this.enableSearch = false,
     this.showZoomControlsOnWeb = true,
     this.showPageIndicator = true,
+    this.showDownloadProgress = true,
+    this.initialPageNumber = 1,
+    this.networkTimeout = const Duration(seconds: 30),
     this.minScale = 0.5,
     this.maxScale = 4.0,
     this.onPageChanged,
     this.onDocumentLoaded,
+    this.onDownloadProgress,
     this.errorBuilder,
     this.searchDebounce = const Duration(milliseconds: 300),
-  }) : assert(minScale > 0 && minScale <= maxScale);
+  }) : assert(minScale > 0 && minScale <= maxScale),
+       assert(initialPageNumber >= 1);
 
   /// The PDF document to render.
   final PdfSource source;
@@ -63,6 +76,25 @@ class PdfViewerWidget extends StatefulWidget {
   /// Whether the "Page X / Y" overlay is shown in the bottom-right corner.
   final bool showPageIndicator;
 
+  /// Whether a linear progress bar is shown across the top of the viewer while
+  /// a network document downloads. Determinate when the server reports a
+  /// content length, indeterminate otherwise. Only applies to
+  /// [PdfSource.uri] — file and bytes sources load without a download step.
+  final bool showDownloadProgress;
+
+  /// The 1-based page the document opens to. Applies to every [PdfSource]
+  /// variant. Defaults to 1.
+  final int initialPageNumber;
+
+  /// Time allowed for each network request to *start responding* (connect and
+  /// return response headers) before it fails and the error UI is shown. This
+  /// bounds a server that never responds; it does not cap the total download,
+  /// so a slow or stalled response body can still take longer than this. With
+  /// [PdfUriSource.preferRangeAccess] it applies per range request. Only
+  /// affects [PdfSource.uri]; file and bytes sources have no network step.
+  /// Defaults to 30 seconds.
+  final Duration networkTimeout;
+
   /// Lower bound for the zoom level passed to `pdfrx`.
   final double minScale;
 
@@ -76,6 +108,13 @@ class PdfViewerWidget extends StatefulWidget {
   /// Called once the document has loaded successfully. Receives the total
   /// page count.
   final void Function(int pageCount)? onDocumentLoaded;
+
+  /// Called as a network document downloads. [received] is the number of bytes
+  /// fetched so far; [total] is the full size when the server reports a
+  /// content length, otherwise `null`. Only fires for [PdfSource.uri]. Use
+  /// this to drive a custom progress UI; the built-in bar is controlled
+  /// separately by [showDownloadProgress].
+  final void Function(int received, int? total)? onDownloadProgress;
 
   /// Optional builder for an error UI shown in place of the document when
   /// loading fails.
@@ -251,27 +290,77 @@ class _PdfViewerWidgetState extends State<PdfViewerWidget> {
           ? null
           : (context, error, stackTrace, documentRef) =>
                 widget.errorBuilder!(context, error),
+      // Only override pdfrx's default loading UI when there's a download to
+      // report on: a network source with either the built-in bar enabled or a
+      // consumer callback attached. File/bytes sources keep the default
+      // spinner, which is momentary since there's no network fetch.
+      loadingBannerBuilder:
+          widget.source is PdfUriSource &&
+              (widget.showDownloadProgress || widget.onDownloadProgress != null)
+          ? _buildLoadingBanner
+          : null,
     );
 
     return switch (widget.source) {
-      PdfUriSource(:final uri, :final headers) => PdfViewer.uri(
-        uri,
-        controller: _controller,
-        params: params,
-        headers: headers,
-      ),
+      PdfUriSource(
+        :final uri,
+        :final headers,
+        :final preferRangeAccess,
+        :final useProgressiveLoading,
+      ) =>
+        PdfViewer.uri(
+          uri,
+          controller: _controller,
+          params: params,
+          initialPageNumber: widget.initialPageNumber,
+          headers: headers,
+          preferRangeAccess: preferRangeAccess,
+          useProgressiveLoading: useProgressiveLoading,
+          timeout: widget.networkTimeout,
+        ),
       PdfFileSource(:final path) => PdfViewer.file(
         path,
         controller: _controller,
         params: params,
+        initialPageNumber: widget.initialPageNumber,
       ),
       PdfBytesSource(:final bytes, :final sourceName) => PdfViewer.data(
         bytes,
         sourceName: sourceName ?? 'document.pdf',
         controller: _controller,
         params: params,
+        initialPageNumber: widget.initialPageNumber,
       ),
     };
+  }
+
+  // pdfrx renders this in place of the document while it downloads, rebuilding
+  // it as bytes arrive, and drops it once the document is ready. The consumer
+  // callback is fired post-frame rather than during this build so a listener
+  // that calls setState can't reenter our build synchronously.
+  Widget _buildLoadingBanner(
+    BuildContext context,
+    int bytesDownloaded,
+    int? totalBytes,
+  ) {
+    final onProgress = widget.onDownloadProgress;
+    if (onProgress != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) onProgress(bytesDownloaded, totalBytes);
+      });
+    }
+    if (!widget.showDownloadProgress) {
+      // Callback-only mode: keep pdfrx's default centered spinner rather than
+      // leaving the loading area blank.
+      return const Center(child: CircularProgressIndicator());
+    }
+    return _PdfDownloadProgressBar(
+      // Determinate only when a content length is known; a zero total would
+      // divide to NaN, so treat it as unknown and fall back to indeterminate.
+      value: (totalBytes != null && totalBytes > 0)
+          ? (bytesDownloaded / totalBytes).clamp(0.0, 1.0)
+          : null,
+    );
   }
 
   @override
@@ -410,6 +499,24 @@ class _PdfSearchBar extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _PdfDownloadProgressBar extends StatelessWidget {
+  const _PdfDownloadProgressBar({required this.value});
+
+  /// Download fraction in `[0, 1]`, or `null` while the total size is unknown
+  /// (renders as an indeterminate bar).
+  final double? value;
+
+  @override
+  Widget build(BuildContext context) {
+    // Pin the bar to the top of the loading area so it reads as a thin
+    // indicator across the top of the viewer, rather than filling it.
+    return Align(
+      alignment: Alignment.topCenter,
+      child: LinearProgressIndicator(value: value),
     );
   }
 }

--- a/packages/codifyiq_pdf_viewer/pubspec.yaml
+++ b/packages/codifyiq_pdf_viewer/pubspec.yaml
@@ -1,6 +1,6 @@
 name: codifyiq_pdf_viewer
 description: A PDF viewer widget with zoom controls, a page indicator, and optional text search, powered by pdfrx.
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/CodifyIQ/codifyiq-core-components/tree/dev/packages/codifyiq_pdf_viewer
 repository: https://github.com/CodifyIQ/codifyiq-core-components/tree/dev/packages/codifyiq_pdf_viewer
 issue_tracker: https://github.com/CodifyIQ/codifyiq-core-components/issues

--- a/packages/codifyiq_pdf_viewer/test/pdf_source_test.dart
+++ b/packages/codifyiq_pdf_viewer/test/pdf_source_test.dart
@@ -1,0 +1,68 @@
+import 'dart:typed_data';
+
+import 'package:codifyiq_pdf_viewer/codifyiq_pdf_viewer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // PdfSource equality is load-bearing: PdfViewerWidget only reloads the
+  // document when the new source is unequal to the old one. These tests pin
+  // that contract so a regression in == / hashCode (e.g. dropping a field)
+  // that would silently stop reloads gets caught here.
+  final uri = Uri.parse('https://example.com/doc.pdf');
+  final otherUri = Uri.parse('https://example.com/other.pdf');
+
+  group('PdfUriSource equality', () {
+    test('equal for the same uri and defaults', () {
+      expect(PdfSource.uri(uri), PdfSource.uri(uri));
+      expect(PdfSource.uri(uri).hashCode, PdfSource.uri(uri).hashCode);
+    });
+
+    test('unequal when the uri differs', () {
+      expect(PdfSource.uri(uri), isNot(PdfSource.uri(otherUri)));
+    });
+
+    test('unequal when preferRangeAccess differs', () {
+      expect(
+        PdfSource.uri(uri, preferRangeAccess: true),
+        isNot(PdfSource.uri(uri)),
+      );
+    });
+
+    test('unequal when useProgressiveLoading differs', () {
+      // Default is true, so an explicit false must not compare equal.
+      expect(
+        PdfSource.uri(uri, useProgressiveLoading: false),
+        isNot(PdfSource.uri(uri)),
+      );
+    });
+
+    test('equality reflects header contents, not map identity', () {
+      expect(
+        PdfSource.uri(uri, headers: {'Authorization': 'Bearer a'}),
+        PdfSource.uri(uri, headers: {'Authorization': 'Bearer a'}),
+      );
+      expect(
+        PdfSource.uri(uri, headers: {'Authorization': 'Bearer a'}),
+        isNot(PdfSource.uri(uri, headers: {'Authorization': 'Bearer b'})),
+      );
+    });
+  });
+
+  group('PdfFileSource / PdfBytesSource equality', () {
+    test('files compare by path', () {
+      expect(PdfSource.file('/a.pdf'), PdfSource.file('/a.pdf'));
+      expect(PdfSource.file('/a.pdf'), isNot(PdfSource.file('/b.pdf')));
+    });
+
+    test('bytes compare by identity, not content', () {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      expect(PdfSource.bytes(bytes), PdfSource.bytes(bytes));
+      // A distinct buffer with identical content is intentionally unequal so
+      // callers can force a reload by passing a fresh Uint8List.
+      expect(
+        PdfSource.bytes(bytes),
+        isNot(PdfSource.bytes(Uint8List.fromList([1, 2, 3]))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
…progressive loading, download progress, initial page, network timeout